### PR TITLE
Remove redundant nil check in config test

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -367,9 +367,6 @@ logLevel: DEBUG
 	if err != nil {
 		t.Fatalf("New() with valid config file returned error: %v", err)
 	}
-	if cfg == nil {
-		t.Fatal("New() should return config for valid file")
-	}
 	if cfg.Api.Port != 9999 {
 		t.Errorf("Api.Port = %d, want 9999", cfg.Api.Port)
 	}


### PR DESCRIPTION
This PR removes a redundant nil check from the config test suite.

## Summary
Simplified the test logic by removing an unnecessary nil assertion that was already covered by the preceding error check.

## Key Changes
- Removed redundant `if cfg == nil` check from `TestNew()` in `config/config_test.go`
- The error check on line 367 (`if err != nil`) already ensures that `cfg` is valid when no error is returned, making the explicit nil check superfluous

## Details
The removed check was defensive but unnecessary since the Go convention is that when a function returns an error, the other return values should not be relied upon. The preceding error check already validates that the function executed successfully, implicitly ensuring `cfg` is not nil.

https://claude.ai/code/session_014jq3k7LjoSUmKkagaJSJe2