### PR TITLE
ci: add GitHub Release job and drop redundant task css in build-docker

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,17 +76,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: '1.24'
-
-      - name: Install Task
-        run: go install github.com/go-task/task/v3/cmd/task@latest
-
-      - name: Build CSS (required for go:embed)
-        run: task css
-
       - name: Compute version and Docker tags
         id: version
         run: |
@@ -139,3 +128,31 @@ jobs:
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.url=https://github.com/${{ github.repository }}
             org.opencontainers.image.licenses=BSD-2-Clause
+
+  release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    needs: build-artifacts
+    if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download binaries
+        uses: actions/download-artifact@v4
+        with:
+          name: binaries-${{ github.sha }}
+          path: dist/
+
+      - name: Download packages
+        uses: actions/download-artifact@v4
+        with:
+          name: packages-${{ github.sha }}
+          path: dist/
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*
+          generate_release_notes: true
+          prerelease: ${{ contains(github.ref_name, '-rc') || contains(github.ref_name, '-beta') || contains(github.ref_name, '-alpha') }}


### PR DESCRIPTION
On tag push (v*), a new `release` job downloads the binaries and packages built by `build-artifacts` and publishes them as GitHub Release assets via softprops/action-gh-release. Tags containing -rc/-beta/-alpha are automatically marked as pre-release.

Also removes the `Set up Go` + `Install Task` + `Build CSS` steps from `build-docker` — CSS is now compiled directly inside the Docker builder stage, so there is nothing to prepare on the runner.

https://claude.ai/code/session_01GwPe5tCsib8gdiU7UNfH1N