### PR TITLE
Skip zero/invalid MPRIS positions to prevent seeker reset

### DIFF
--- a/backend/mpris/heartbeat.go
+++ b/backend/mpris/heartbeat.go
@@ -107,6 +107,15 @@ func (h *Heartbeat) updatePlayingPositions() bool {
 			continue
 		}
 
+		// Some MPRIS implementations (e.g. go-librespot) return 0 for Position
+		// even during active playback. Skip the update to avoid resetting the
+		// seeker to the beginning of the track.
+		pos, ok := extractInt64(variant)
+		if !ok || pos <= 0 {
+			logger.Debug("[mpris] skipping zero/invalid position for %s", player.BusName)
+			continue
+		}
+
 		// Update via UpdateProperty (handles cache properly)
 		if err := h.backend.UpdateProperty(player.BusName, "Position", variant); err != nil {
 			logger.Warn("[mpris] failed to update position for %s: %v", player.BusName, err)


### PR DESCRIPTION
## Summary
Added validation to skip position updates when MPRIS players return zero or invalid position values during active playback, preventing the seeker from being reset to the beginning of tracks.

## Key Changes
- Added position validation in `updatePlayingPositions()` to extract and check the position value before updating
- Skip position updates when the extracted position is invalid or <= 0
- Added debug logging to indicate when position updates are skipped for a player

## Implementation Details
This fix addresses an issue with certain MPRIS implementations (e.g. go-librespot) that return 0 for the Position property even during active playback. Without this validation, these zero values would be propagated as position updates, causing the seeker to reset to the beginning of the track. The new check ensures only valid, positive position values are used for updates.

https://claude.ai/code/session_01LiuS6sRFsMvuPwHx6onQaz