### PR TITLE
fix(mpris): decode percent-encoded file:// cover URIs

### DIFF
--- a/api/handlers_mpris_test.go
+++ b/api/handlers_mpris_test.go
@@ -19,6 +19,17 @@ func TestCoverHandler(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Path containing a space — MPRIS daemons percent-encode it per RFC 3986.
+	encodedDir := filepath.Join(tmpDir, "Transmission pirate")
+	if err := os.Mkdir(encodedDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	encodedCoverPath := filepath.Join(encodedDir, "folder.jpg")
+	if err := os.WriteFile(encodedCoverPath, []byte("encoded-image-data"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	encodedArtUrl := "file://" + strings.ReplaceAll(encodedCoverPath, " ", "%20")
+
 	tests := []struct {
 		name           string
 		busName        string
@@ -54,6 +65,17 @@ func TestCoverHandler(t *testing.T) {
 			},
 			wantStatusCode: http.StatusOK,
 			wantBody:       "fake-image-data",
+		},
+		{
+			name:    "file:// URL with percent-encoded path serves file",
+			busName: "org.mpris.MediaPlayer2.mpd",
+			getPlayer: func(string) (*mpris.Player, error) {
+				return &mpris.Player{Metadata: map[string]string{
+					"mpris:artUrl": encodedArtUrl,
+				}}, nil
+			},
+			wantStatusCode: http.StatusOK,
+			wantBody:       "encoded-image-data",
 		},
 		{
 			name:    "http:// URL redirects",

--- a/api/players.go
+++ b/api/players.go
@@ -3,6 +3,7 @@ package api
 import (
 	"errors"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/b0bbywan/go-odio-api/backend/mpris"
@@ -147,7 +148,15 @@ func CoverHandler(getPlayer func(string) (*mpris.Player, error)) http.HandlerFun
 		case artUrl == "":
 			http.NotFound(w, r)
 		case strings.HasPrefix(artUrl, "file://"):
-			http.ServeFile(w, r, strings.TrimPrefix(artUrl, "file://"))
+			// Standards-compliant MPRIS daemons percent-encode reserved
+			// characters in file:// URIs (RFC 3986). Parse to recover the
+			// decoded filesystem path.
+			u, err := url.Parse(artUrl)
+			if err != nil {
+				http.NotFound(w, r)
+				return
+			}
+			http.ServeFile(w, r, u.Path)
 		case strings.HasPrefix(artUrl, "http://"), strings.HasPrefix(artUrl, "https://"):
 			http.Redirect(w, r, artUrl, http.StatusTemporaryRedirect)
 		default:


### PR DESCRIPTION
Closes #112. RFC 3986-compliant MPRIS daemons percent-encode reserved chars in mpris:artUrl; parse the URI so paths with spaces/accents resolve correctly instead of 404ing.