### PR TITLE
refactor(upgrade): unify run lifecycle into a persisted state machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,7 +428,7 @@ The detector's result file contract is `current`, `latest`, `upgrade_available` 
   "upgrade_available": true,
   "checked_at": "2026-06-15T20:46:34Z",
   "extra": { "roles": ["setup", "..."], "manifest": { "odios": "2026.6.0b1" } },
-  "run": { "state": "running", "percent": 42, "step": "mpd" },  // only during a run
+  "run": { "state": "running", "percent": 42, "step": "mpd" },  // "idle" until a run, "failed" if the last one failed
   "can_check": true,                                            // POST /upgrade/check available
   "can_upgrade": true                                           // POST /upgrade/start available
 }
@@ -440,9 +440,10 @@ Detector status and run lifecycle stream as `upgrade.info`; live run progress st
 // upgrade.info — detector status (on result-file change): the contract fields + "extra", no "run" or capability flags
 {"current": "2026.5.0b3", "latest": "2026.6.0b1", "upgrade_available": true, "checked_at": "...", "extra": { /* ... */ }}
 
-// upgrade.info — run lifecycle; success is the systemd job result (authoritative)
-{"state": "running"}
-{"state": "finished", "success": true}
+// upgrade.info — run lifecycle; the state is the verdict (systemd job result is authoritative):
+// "idle" (none or last succeeded), "running", "failed"
+{"state": "running", "percent": 42, "step": "mpd"}
+{"state": "failed"}
 
 // upgrade.progress — emitted by the upgrade script over the socket; minimum contract below, add any field you want
 {"event": "begin",    "total": 7}

--- a/backend/upgrade/bus_test.go
+++ b/backend/upgrade/bus_test.go
@@ -1,0 +1,150 @@
+package upgrade
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/b0bbywan/go-odio-api/backend/systemd"
+	"github.com/b0bbywan/go-odio-api/events"
+)
+
+// fakeSystemd is a systemdControl that records calls and returns canned results,
+// so the bus-driven paths run without a D-Bus connection.
+type fakeSystemd struct {
+	startErr     error
+	triggerErr   error
+	refreshSvc   *systemd.Service
+	refreshErr   error
+	startCalls   []string
+	triggerCalls []string
+}
+
+func (f *fakeSystemd) StartService(name string, _ systemd.UnitScope) error {
+	f.startCalls = append(f.startCalls, name)
+	return f.startErr
+}
+
+func (f *fakeSystemd) TriggerUserUnit(_ context.Context, name string) error {
+	f.triggerCalls = append(f.triggerCalls, name)
+	return f.triggerErr
+}
+
+func (f *fakeSystemd) RefreshService(_ context.Context, _ string, _ systemd.UnitScope) (*systemd.Service, error) {
+	return f.refreshSvc, f.refreshErr
+}
+
+func newBackend(t *testing.T, sysd systemdControl) *UpgradeBackend {
+	t.Helper()
+	return &UpgradeBackend{
+		ctx:         context.Background(),
+		checkUnit:   "odio-check.service",
+		upgradeUnit: "odio-upgrade.service",
+		run:         newRun(""),
+		events:      make(chan events.Event, 16),
+		systemd:     sysd,
+	}
+}
+
+func recvRunState(t *testing.T, u *UpgradeBackend) RunState {
+	t.Helper()
+	e, ok := recv(t, u.Events(), time.Second)
+	if !ok {
+		t.Fatal("expected an upgrade.info event, got none")
+	}
+	rs, ok := e.Data.(RunState)
+	if !ok {
+		t.Fatalf("event data = %T, want RunState", e.Data)
+	}
+	return rs
+}
+
+func TestStartUpgradeTriggersAndEmitsRunning(t *testing.T) {
+	fake := &fakeSystemd{}
+	u := newBackend(t, fake)
+
+	if err := u.StartUpgrade(); err != nil {
+		t.Fatalf("StartUpgrade = %v, want nil", err)
+	}
+	if len(fake.triggerCalls) != 1 || fake.triggerCalls[0] != "odio-upgrade.service" {
+		t.Fatalf("triggerCalls = %v, want [odio-upgrade.service]", fake.triggerCalls)
+	}
+	if rs := recvRunState(t, u); rs.State != stateRunning || rs.Origin != originSystemd {
+		t.Fatalf("event = %+v, want running/systemd", rs)
+	}
+}
+
+// A trigger that fails records a failure verdict instead of rewinding to idle,
+// so the UI shows the failure rather than a phantom-clean state.
+func TestStartUpgradeTriggerFailureRecordsVerdict(t *testing.T) {
+	wantErr := errors.New("dbus down")
+	fake := &fakeSystemd{triggerErr: wantErr}
+	u := newBackend(t, fake)
+
+	if err := u.StartUpgrade(); !errors.Is(err, wantErr) {
+		t.Fatalf("StartUpgrade = %v, want %v", err, wantErr)
+	}
+	rs := recvRunState(t, u)
+	if rs.State != stateFailed {
+		t.Fatalf("event = %+v, want failed", rs)
+	}
+	if u.run.isRunning() {
+		t.Error("run still marked running after a failed trigger")
+	}
+}
+
+func TestCheckNowTriggersCheckUnit(t *testing.T) {
+	fake := &fakeSystemd{}
+	u := newBackend(t, fake)
+
+	if err := u.CheckNow(); err != nil {
+		t.Fatalf("CheckNow = %v, want nil", err)
+	}
+	if len(fake.startCalls) != 1 || fake.startCalls[0] != "odio-check.service" {
+		t.Fatalf("startCalls = %v, want [odio-check.service]", fake.startCalls)
+	}
+}
+
+// resumeIfRunning on a unit still activating claims the run and re-announces it.
+func TestResumeIfRunningActivatingResumes(t *testing.T) {
+	fake := &fakeSystemd{refreshSvc: &systemd.Service{ActiveState: "activating"}}
+	u := newBackend(t, fake)
+
+	u.resumeIfRunning()
+	if rs := recvRunState(t, u); rs.State != stateRunning || rs.Origin != originSystemd {
+		t.Fatalf("event = %+v, want running/systemd", rs)
+	}
+}
+
+// A run restored as running whose unit is already terminal ended while we were
+// down: resume records the missed verdict.
+func TestResumeIfRunningTerminalWhileDownRecordsVerdict(t *testing.T) {
+	fake := &fakeSystemd{refreshSvc: &systemd.Service{ActiveState: "failed"}}
+	u := newBackend(t, fake)
+	u.run.start(originSystemd) // restored from a persisted snapshot
+
+	u.resumeIfRunning()
+	rs := recvRunState(t, u)
+	if rs.State != stateFailed {
+		t.Fatalf("event = %+v, want failed", rs)
+	}
+}
+
+// A socket-driven run owns its lifecycle, so the unit reaching a terminal state
+// must not close it.
+func TestOnServiceEventIgnoresSocketRun(t *testing.T) {
+	u := newBackend(t, &fakeSystemd{})
+	u.run.start(originSocket)
+
+	u.onServiceEvent(events.Event{
+		Type: events.TypeServiceUpdated,
+		Data: systemd.Service{Name: "odio-upgrade.service", Scope: systemd.ScopeUser, ActiveState: "failed"},
+	})
+	if _, ok := recv(t, u.Events(), 200*time.Millisecond); ok {
+		t.Fatal("a socket run must not be closed by the unit's terminal state")
+	}
+	if !u.run.isRunning() {
+		t.Error("socket run should still be running")
+	}
+}

--- a/backend/upgrade/listener.go
+++ b/backend/upgrade/listener.go
@@ -114,13 +114,19 @@ func parseProgress(line []byte) (progressLine, bool) {
 	}
 }
 
-// applyRunProgress advances the live run state; "end" is left for the terminal unit state to clear.
+// applyRunProgress advances the run from the socket stream. begin and a closing
+// end emit upgrade.info so the badge flips state; progress rides the raw
+// upgrade.progress line the caller sends, so it needs no extra info event.
 func (u *UpgradeBackend) applyRunProgress(p progressLine) {
 	switch *p.Event {
 	case "begin":
-		zero := 0
-		u.runState.Store(&RunState{State: "running", Percent: &zero})
+		u.run.begin(*p.Total)
+		u.notify(events.Event{Type: events.TypeUpgradeInfo, Data: u.run.snapshot()})
 	case "progress":
-		u.runState.Store(&RunState{State: "running", Percent: p.Percent, Step: p.Step})
+		u.run.progress(*p.Percent, *p.Step)
+	case "end":
+		if u.run.finish(*p.Success) {
+			u.notify(events.Event{Type: events.TypeUpgradeInfo, Data: u.run.snapshot()})
+		}
 	}
 }

--- a/backend/upgrade/progress_test.go
+++ b/backend/upgrade/progress_test.go
@@ -34,8 +34,8 @@ func TestParseProgressContract(t *testing.T) {
 }
 
 func TestStartUpgradeRejectsConcurrentRun(t *testing.T) {
-	u := &UpgradeBackend{upgradeUnit: "upgrade.service", systemd: &systemd.SystemdBackend{}}
-	u.running.Store(true) // a run is already in flight
+	u := &UpgradeBackend{upgradeUnit: "upgrade.service", systemd: &systemd.SystemdBackend{}, run: newRun("")}
+	u.run.start(originSystemd) // a run is already in flight
 
 	if err := u.StartUpgrade(); !errors.Is(err, ErrUpgradeInProgress) {
 		t.Fatalf("StartUpgrade while running = %v, want ErrUpgradeInProgress", err)

--- a/backend/upgrade/run.go
+++ b/backend/upgrade/run.go
@@ -1,0 +1,198 @@
+package upgrade
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/b0bbywan/go-odio-api/logger"
+)
+
+const (
+	stateIdle    = "idle"
+	stateRunning = "running"
+	stateFailed  = "failed"
+
+	originSystemd = "systemd"
+	originSocket  = "socket"
+)
+
+// run is the single source of truth for the upgrade run lifecycle, replacing the
+// former running/runState pair. The state is always set: idle means none-or-last-
+// succeeded, so a fresh install starts from idle rather than an absent run the
+// clients would have to special-case.
+//
+// Progress is kept in memory and only flushed to disk on Close. The state file
+// is a shutdown dump for load() at next boot, not a live journal: persisting
+// every progress tick would hammer the SD card on a Pi for no gain. A SIGKILL
+// or power loss therefore loses the in-memory percent; resumeIfRunning then
+// reconciles against systemd for a systemd-origin run, and a socket-origin run
+// simply waits for its CLI client to reconnect.
+type run struct {
+	mu   sync.Mutex
+	path string
+	st   RunState
+}
+
+func newRun(path string) *run {
+	return &run{path: path, st: defaultState()}
+}
+
+func defaultState() RunState {
+	return RunState{State: stateIdle}
+}
+
+// load restores the snapshot persisted at the last clean shutdown, leaving the
+// idle default in place on a missing or invalid file.
+func (r *run) load() {
+	if r.path == "" {
+		logger.Warn("[upgrade] no state file configured, starting from idle (a run cannot survive a restart)")
+		return
+	}
+	data, err := os.ReadFile(r.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			logger.Info("[upgrade] no run state file at %s, starting from idle", r.path)
+		} else {
+			logger.Warn("[upgrade] cannot read run state %s, starting from idle: %v", r.path, err)
+		}
+		return
+	}
+	var st RunState
+	if err := json.Unmarshal(data, &st); err != nil || st.State == "" {
+		logger.Warn("[upgrade] run state %s invalid (%q), keeping idle default: %v", r.path, string(data), err)
+		return
+	}
+	r.mu.Lock()
+	r.st = st
+	r.mu.Unlock()
+	logger.Info("[upgrade] restored run state from %s: state=%s origin=%s percent=%s", r.path, st.State, st.Origin, pctLabel(st.Percent))
+}
+
+// save writes the current snapshot atomically, creating the parent dir if it is
+// missing. Called once from Close; a failure here means the next boot cannot
+// restore the run, so every exit path is logged.
+func (r *run) save() {
+	if r.path == "" {
+		logger.Warn("[upgrade] no state file configured, run state not persisted")
+		return
+	}
+	r.mu.Lock()
+	st := r.st
+	data, err := json.Marshal(st)
+	r.mu.Unlock()
+	if err != nil {
+		logger.Warn("[upgrade] cannot marshal run state: %v", err)
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(r.path), 0o700); err != nil {
+		logger.Warn("[upgrade] cannot create state dir %s, run state not persisted: %v", filepath.Dir(r.path), err)
+		return
+	}
+	tmp := r.path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		logger.Warn("[upgrade] cannot write run state %s: %v", tmp, err)
+		return
+	}
+	if err := os.Rename(tmp, r.path); err != nil {
+		logger.Warn("[upgrade] cannot commit run state %s: %v", r.path, err)
+		return
+	}
+	logger.Info("[upgrade] saved run state to %s: state=%s origin=%s percent=%s", r.path, st.State, st.Origin, pctLabel(st.Percent))
+}
+
+func pctLabel(p *int) string {
+	if p == nil {
+		return "n/a"
+	}
+	return strconv.Itoa(*p)
+}
+
+// start reserves the run for origin. It returns false when one is already in
+// flight: this is the concurrency guard the atomic.Bool used to provide.
+func (r *run) start(origin string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.st.State == stateRunning {
+		logger.Debug("[upgrade] run start rejected, already running (origin=%s)", r.st.Origin)
+		return false
+	}
+	r.st = RunState{State: stateRunning, Origin: origin, StartedAt: nowRFC3339()}
+	logger.Info("[upgrade] run started (origin=%s)", origin)
+	return true
+}
+
+// begin handles the socket "begin" line. A CLI-driven run that never went
+// through start adopts the socket origin here, which is what lets an upgrade
+// launched outside the systemd unit show up in the UI.
+func (r *run) begin(total int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.st.State != stateRunning {
+		r.st = RunState{State: stateRunning, Origin: originSocket, StartedAt: nowRFC3339()}
+		logger.Info("[upgrade] run adopted from socket begin (total=%d)", total)
+	} else {
+		logger.Debug("[upgrade] socket begin on an already-running %s run (total=%d)", r.st.Origin, total)
+	}
+	zero := 0
+	r.st.Percent = &zero
+	r.st.Step = nil
+}
+
+func (r *run) progress(pct int, step string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.st.State != stateRunning {
+		logger.Debug("[upgrade] dropping progress %d%% (%s): no run in flight", pct, step)
+		return
+	}
+	r.st.Percent = &pct
+	r.st.Step = &step
+	logger.Debug("[upgrade] run progress %d%% (%s)", pct, step)
+}
+
+// finish records the verdict and returns false when there was no run to close.
+// The two terminal sources, the socket "end" line and the unit reaching a
+// terminal state, can race; the bool lets the caller emit finished exactly once.
+func (r *run) finish(success bool) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.st.State != stateRunning {
+		return false
+	}
+	state := stateIdle
+	if !success {
+		state = stateFailed
+	}
+	r.st = RunState{
+		State:      state,
+		Origin:     r.st.Origin,
+		StartedAt:  r.st.StartedAt,
+		FinishedAt: nowRFC3339(),
+	}
+	logger.Info("[upgrade] run finished: state=%s origin=%s", state, r.st.Origin)
+	return true
+}
+
+func (r *run) snapshot() RunState {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.st
+}
+
+func (r *run) isRunning() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.st.State == stateRunning
+}
+
+func (r *run) origin() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.st.Origin
+}
+
+func nowRFC3339() string { return time.Now().UTC().Format(time.RFC3339) }

--- a/backend/upgrade/run_test.go
+++ b/backend/upgrade/run_test.go
@@ -1,0 +1,191 @@
+package upgrade
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/b0bbywan/go-odio-api/backend/systemd"
+	"github.com/b0bbywan/go-odio-api/events"
+)
+
+func strp(s string) *string { return &s }
+func intp(n int) *int       { return &n }
+func boolp(b bool) *bool    { return &b }
+
+// TestRunStatePersistsAcrossRestart is the save→load round trip: a terminal
+// verdict written at shutdown must come back intact at the next boot. A failed
+// verdict is used so the result is distinguishable from the idle default. The
+// parent dir does not exist yet, so this also covers save() creating it — its
+// absence silently dropped every snapshot, losing the run on restart.
+func TestRunStatePersistsAcrossRestart(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "odio-api", "upgrade-run.json")
+
+	r := newRun(path)
+	r.start(originSystemd)
+	r.progress(70, "installing")
+	r.finish(false)
+	r.save()
+
+	restored := newRun(path)
+	restored.load()
+	got := restored.snapshot()
+	if got.State != stateFailed || got.Origin != originSystemd {
+		t.Fatalf("restored = %+v, want failed/systemd", got)
+	}
+	if got.StartedAt == "" || got.FinishedAt == "" {
+		t.Errorf("restored timestamps empty: %+v", got)
+	}
+}
+
+// TestRunStateGracefulRestartKeepsPercent is the self-upgrade case: odio-api is
+// restarted by its own upgrade unit while a systemd run is mid-flight. The
+// in-flight percent must survive the save→load round trip (parent dir absent),
+// so the resumed run shows real progress, not an indeterminate ring.
+func TestRunStateGracefulRestartKeepsPercent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "odio-api", "upgrade-run.json")
+
+	r := newRun(path)
+	r.start(originSystemd)
+	r.begin(7)
+	r.progress(42, "mpd")
+	r.save()
+
+	restored := newRun(path)
+	restored.load()
+	if got := restored.snapshot(); got.State != stateRunning || got.Percent == nil || *got.Percent != 42 {
+		t.Fatalf("restored = %+v, want running with percent 42", got)
+	}
+}
+
+// TestRunStateRestoresRunningSocketRun covers the resume case: a socket run
+// still in flight at shutdown reloads as running so resumeIfRunning can await
+// the client.
+func TestRunStateRestoresRunningSocketRun(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "upgrade-run.json")
+
+	r := newRun(path)
+	r.start(originSocket)
+	r.progress(40, "mpd")
+	r.save()
+
+	restored := newRun(path)
+	restored.load()
+	if !restored.isRunning() || restored.origin() != originSocket {
+		t.Fatalf("restored = %+v, want running/socket", restored.snapshot())
+	}
+}
+
+func TestRunStateLoadMissingKeepsDefault(t *testing.T) {
+	r := newRun(filepath.Join(t.TempDir(), "absent.json"))
+	r.load()
+	if got := r.snapshot(); got.State != stateIdle {
+		t.Fatalf("missing-file load = %+v, want idle default", got)
+	}
+}
+
+func TestRunStateLoadInvalidKeepsDefault(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "upgrade-run.json")
+	writeFile(t, path, `{not json`)
+
+	r := newRun(path)
+	r.load()
+	if got := r.snapshot(); got.State != stateIdle {
+		t.Fatalf("invalid-file load = %+v, want idle default", got)
+	}
+}
+
+// TestRunBeginAdoptsSocketOrigin: a run that never went through start (CLI
+// upgrade outside the unit) takes the socket origin from its begin line.
+func TestRunBeginAdoptsSocketOrigin(t *testing.T) {
+	r := newRun("")
+	r.begin(3)
+	got := r.snapshot()
+	if got.State != stateRunning || got.Origin != originSocket || got.Percent == nil || *got.Percent != 0 {
+		t.Fatalf("begin = %+v, want running/socket/0%%", got)
+	}
+}
+
+// A begin arriving on an already-started systemd run must not steal its origin.
+func TestRunBeginKeepsExistingOrigin(t *testing.T) {
+	r := newRun("")
+	r.start(originSystemd)
+	r.begin(3)
+	if got := r.origin(); got != originSystemd {
+		t.Fatalf("origin after begin = %q, want %q", got, originSystemd)
+	}
+}
+
+func TestRunFinishIsIdempotent(t *testing.T) {
+	r := newRun("")
+	r.start(originSystemd)
+	if !r.finish(true) {
+		t.Fatal("first finish = false, want true")
+	}
+	if r.finish(false) {
+		t.Fatal("second finish = true, want false (no run to close)")
+	}
+	if got := r.snapshot(); got.State != stateIdle {
+		t.Errorf("verdict = %+v, want unchanged idle (success)", got)
+	}
+}
+
+// TestApplyRunProgressSocketLifecycle drives the full begin→progress→end stream
+// and asserts begin/end emit upgrade.info while progress does not, and that a
+// repeated end is a no-op.
+func TestApplyRunProgressSocketLifecycle(t *testing.T) {
+	u := &UpgradeBackend{run: newRun(""), events: make(chan events.Event, 16)}
+
+	u.applyRunProgress(progressLine{Event: strp("begin"), Total: intp(3)})
+	e, ok := recv(t, u.Events(), time.Second)
+	if !ok {
+		t.Fatal("begin emitted no upgrade.info event")
+	}
+	if rs, _ := e.Data.(RunState); rs.State != stateRunning || rs.Origin != originSocket {
+		t.Fatalf("begin event = %+v, want running/socket", e.Data)
+	}
+
+	u.applyRunProgress(progressLine{Event: strp("progress"), Percent: intp(50), Step: strp("mpd")})
+	if _, ok := recv(t, u.Events(), 200*time.Millisecond); ok {
+		t.Fatal("progress should not emit an info event")
+	}
+	if s := u.run.snapshot(); s.Percent == nil || *s.Percent != 50 {
+		t.Fatalf("after progress = %+v, want percent 50", s)
+	}
+
+	u.applyRunProgress(progressLine{Event: strp("end"), Success: boolp(false)})
+	e, ok = recv(t, u.Events(), time.Second)
+	if !ok {
+		t.Fatal("end emitted no upgrade.info event")
+	}
+	if rs, _ := e.Data.(RunState); rs.State != stateFailed {
+		t.Fatalf("end event = %+v, want failed", e.Data)
+	}
+
+	u.applyRunProgress(progressLine{Event: strp("end"), Success: boolp(false)})
+	if _, ok := recv(t, u.Events(), 200*time.Millisecond); ok {
+		t.Fatal("a second end should not emit (finish is a no-op)")
+	}
+}
+
+// TestResumeIfRunningSocketAwaitsReconnect: a restored socket run owns its
+// lifecycle, so resume re-announces it without consulting systemd.
+func TestResumeIfRunningSocketAwaitsReconnect(t *testing.T) {
+	u := &UpgradeBackend{
+		run:     newRun(""),
+		events:  make(chan events.Event, 16),
+		systemd: &systemd.SystemdBackend{}, // never touched on the socket path
+		ctx:     context.Background(),
+	}
+	u.run.start(originSocket)
+
+	u.resumeIfRunning()
+	e, ok := recv(t, u.Events(), time.Second)
+	if !ok {
+		t.Fatal("resume of a socket run emitted no event")
+	}
+	if rs, _ := e.Data.(RunState); rs.State != stateRunning || rs.Origin != originSocket {
+		t.Fatalf("resume event = %+v, want running/socket", e.Data)
+	}
+}

--- a/backend/upgrade/types.go
+++ b/backend/upgrade/types.go
@@ -84,6 +84,15 @@ type StatusResponse struct {
 	CanUpgrade bool     `json:"can_upgrade"`
 }
 
+// systemdControl is the slice of systemd the upgrade backend depends on: enough
+// to trigger the check/upgrade units and read one unit's state on resume.
+// *systemd.SystemdBackend satisfies it; tests supply a fake.
+type systemdControl interface {
+	StartService(name string, scope systemd.UnitScope) error
+	TriggerUserUnit(ctx context.Context, name string) error
+	RefreshService(ctx context.Context, name string, scope systemd.UnitScope) (*systemd.Service, error)
+}
+
 // UpgradeBackend watches a detector result file and triggers systemd user units to upgrade.
 type UpgradeBackend struct {
 	ctx            context.Context
@@ -92,9 +101,9 @@ type UpgradeBackend struct {
 	upgradeUnit    string
 	progressSocket string
 
-	systemd  *systemd.SystemdBackend // triggers units (user scope); may be nil
-	status   cache.Value[*Status]    // last valid detector result; nil until first read
-	lastRaw  []byte                  // last accepted result file bytes, for change dedup
+	systemd  systemdControl       // triggers and reads units (user scope); nil interface when disabled
+	status   cache.Value[*Status] // last valid detector result; nil until first read
+	lastRaw  []byte               // last accepted result file bytes, for change dedup
 	watcher  *fsnotify.Watcher
 	listener net.Listener // unix socket the upgrade script streams progress to
 	run      *run         // run lifecycle and persisted snapshot

--- a/backend/upgrade/types.go
+++ b/backend/upgrade/types.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/fsnotify/fsnotify"
@@ -21,12 +20,15 @@ var ErrUnitNotConfigured = errors.New("upgrade: systemd unit not configured")
 
 var ErrUpgradeInProgress = errors.New("upgrade: already in progress")
 
-// RunState is the run lifecycle: the upgrade.info payload and the status "run" snapshot (nil when idle).
+// RunState is the run lifecycle: the upgrade.info payload and the status "run"
+// snapshot. The verdict is the state itself; idle is none or last succeeded.
 type RunState struct {
-	State   string  `json:"state"`             // "running" | "finished"
-	Percent *int    `json:"percent,omitempty"` // live, while running
-	Step    *string `json:"step,omitempty"`    // live, while running
-	Success *bool   `json:"success,omitempty"` // set once finished
+	State      string  `json:"state"`                 // "idle" | "running" | "failed"
+	Origin     string  `json:"origin,omitempty"`      // "systemd" | "socket"
+	Percent    *int    `json:"percent,omitempty"`     // live, while running
+	Step       *string `json:"step,omitempty"`        // live, while running
+	StartedAt  string  `json:"started_at,omitempty"`  // RFC3339
+	FinishedAt string  `json:"finished_at,omitempty"` // RFC3339
 }
 
 // Status is the detector result; UnmarshalJSON routes unknown fields verbatim into Extra.
@@ -74,12 +76,12 @@ func (s *Status) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-// StatusResponse is the GET /upgrade payload: Status, the live run, and available triggers.
+// StatusResponse is the GET /upgrade payload: Status, the run snapshot, and available triggers.
 type StatusResponse struct {
 	Status
-	Run        *RunState `json:"run,omitempty"`
-	CanCheck   bool      `json:"can_check"`
-	CanUpgrade bool      `json:"can_upgrade"`
+	Run        RunState `json:"run"`
+	CanCheck   bool     `json:"can_check"`
+	CanUpgrade bool     `json:"can_upgrade"`
 }
 
 // UpgradeBackend watches a detector result file and triggers systemd user units to upgrade.
@@ -94,9 +96,8 @@ type UpgradeBackend struct {
 	status   cache.Value[*Status]    // last valid detector result; nil until first read
 	lastRaw  []byte                  // last accepted result file bytes, for change dedup
 	watcher  *fsnotify.Watcher
-	listener net.Listener           // unix socket the upgrade script streams progress to
-	running  atomic.Bool            // guards against concurrent upgrades
-	runState cache.Value[*RunState] // live run progress for the status endpoint; nil when idle
+	listener net.Listener // unix socket the upgrade script streams progress to
+	run      *run         // run lifecycle and persisted snapshot
 	wg       sync.WaitGroup
 	events   chan events.Event
 

--- a/backend/upgrade/upgrade.go
+++ b/backend/upgrade/upgrade.go
@@ -37,6 +37,7 @@ func New(ctx context.Context, cfg *config.UpgradeConfig, sysd *systemd.SystemdBa
 		upgradeUnit:    cfg.UpgradeUnit,
 		progressSocket: cfg.ProgressSocket,
 		systemd:        sysd,
+		run:            newRun(cfg.StateFile),
 		events:         make(chan events.Event, 16),
 	}, nil
 }
@@ -47,6 +48,7 @@ func (u *UpgradeBackend) UseEventStream(s events.Stream) { u.stream = s }
 // Start loads the current result, then watches the result file, listens for run
 // progress, and tracks the run unit over the bus.
 func (u *UpgradeBackend) Start() error {
+	u.run.load()   // restore a run persisted at the last shutdown before consumers read it
 	u.readResult() // best-effort; a missing file is not an error
 	u.startWatcher()
 	u.startListener()
@@ -72,6 +74,7 @@ func (u *UpgradeBackend) Close() {
 		u.stream.Unsubscribe(u.sub)
 	}
 	u.wg.Wait()
+	u.run.save() // flush the final run snapshot for the next boot
 	u.watcher = nil
 	u.listener = nil
 }
@@ -87,7 +90,7 @@ func (u *UpgradeBackend) GetStatus() *Status {
 // StatusResponse builds the GET /upgrade payload (always non-nil).
 func (u *UpgradeBackend) StatusResponse() StatusResponse {
 	resp := StatusResponse{
-		Run:        u.runState.Load(),
+		Run:        u.run.snapshot(),
 		CanCheck:   u.CanCheck(),
 		CanUpgrade: u.CanUpgrade(),
 	}
@@ -161,18 +164,20 @@ func (u *UpgradeBackend) StartUpgrade() error {
 		logger.Warn("[upgrade] start requested but no upgrade unit available")
 		return ErrUnitNotConfigured
 	}
-	if !u.running.CompareAndSwap(false, true) {
+	if !u.run.start(originSystemd) {
 		logger.Warn("[upgrade] start requested but an upgrade is already running")
 		return ErrUpgradeInProgress
 	}
 	logger.Info("[upgrade] triggering upgrade unit %s, emitting running", u.upgradeUnit)
 	if err := u.systemd.TriggerUserUnit(u.ctx, u.upgradeUnit); err != nil {
-		u.running.Store(false)
+		// The run started and failed to launch; record the verdict rather than
+		// rewinding to idle, so the UI shows the failure.
+		u.run.finish(false)
 		logger.Warn("[upgrade] failed to trigger upgrade unit: %v", err)
+		u.notify(events.Event{Type: events.TypeUpgradeInfo, Data: u.run.snapshot()})
 		return err
 	}
-	u.runState.Store(&RunState{State: "running"})
-	u.notify(events.Event{Type: events.TypeUpgradeInfo, Data: RunState{State: "running"}})
+	u.notify(events.Event{Type: events.TypeUpgradeInfo, Data: u.run.snapshot()})
 	return nil
 }
 
@@ -207,7 +212,9 @@ func (u *UpgradeBackend) consumeEvents() {
 }
 
 // onServiceEvent emits the run verdict once the upgrade unit reaches a terminal
-// state. The CAS guard fires finished exactly once per tracked run.
+// state. A socket-driven run owns its own lifecycle and is closed by its "end"
+// line, not by the unit. finish is idempotent, so a run that streams "end" and
+// also trips the unit's terminal state still emits finished exactly once.
 func (u *UpgradeBackend) onServiceEvent(e events.Event) {
 	svc, ok := e.Data.(systemd.Service)
 	if !ok || svc.Name != u.upgradeUnit || svc.Scope != systemd.ScopeUser {
@@ -218,20 +225,28 @@ func (u *UpgradeBackend) onServiceEvent(e events.Event) {
 	default:
 		return // still activating
 	}
-	u.runState.Reset()
-	if !u.running.CompareAndSwap(true, false) {
+	if u.run.origin() == originSocket {
 		return
 	}
 	success := svc.ActiveState != "failed"
+	if !u.run.finish(success) {
+		return
+	}
 	logger.Info("[upgrade] %s reached %s, emitting finished (success=%v)", u.upgradeUnit, svc.ActiveState, success)
-	u.notify(events.Event{Type: events.TypeUpgradeInfo, Data: RunState{State: "finished", Success: &success}})
+	u.notify(events.Event{Type: events.TypeUpgradeInfo, Data: u.run.snapshot()})
 }
 
-// resumeIfRunning re-attaches to an upgrade triggered before a restart: if the
-// unit is still activating, re-announce running and let completion arrive over
-// the bus like any live run.
+// resumeIfRunning reconciles a restored or out-of-band run at startup. A socket
+// run has no unit to consult and waits for its CLI client to reconnect. For a
+// systemd run it reads the unit: still activating means resume, already terminal
+// means the run finished while we were down, so record its verdict.
 func (u *UpgradeBackend) resumeIfRunning() {
 	if u.systemd == nil {
+		return
+	}
+	if u.run.isRunning() && u.run.origin() == originSocket {
+		logger.Info("[upgrade] resuming socket run, awaiting client reconnect")
+		u.notify(events.Event{Type: events.TypeUpgradeInfo, Data: u.run.snapshot()})
 		return
 	}
 	ctx, cancel := context.WithTimeout(u.ctx, 5*time.Second)
@@ -241,9 +256,18 @@ func (u *UpgradeBackend) resumeIfRunning() {
 		logger.Warn("[upgrade] cannot read %s state on startup: %v", u.upgradeUnit, err)
 		return
 	}
-	if svc.ActiveState == "activating" && u.running.CompareAndSwap(false, true) {
-		logger.Info("[upgrade] %s still running on startup, resuming", u.upgradeUnit)
-		u.runState.Store(&RunState{State: "running"})
-		u.notify(events.Event{Type: events.TypeUpgradeInfo, Data: RunState{State: "running"}})
+	switch {
+	case svc.ActiveState == "activating":
+		// claim it unless we already hold a restored run for this unit.
+		if u.run.isRunning() || u.run.start(originSystemd) {
+			logger.Info("[upgrade] %s still running on startup, resuming", u.upgradeUnit)
+			u.notify(events.Event{Type: events.TypeUpgradeInfo, Data: u.run.snapshot()})
+		}
+	case u.run.isRunning():
+		// restored running but the unit is terminal: it ended while we were down.
+		if u.run.finish(svc.ActiveState != "failed") {
+			logger.Info("[upgrade] %s ended while down (%s), recording verdict", u.upgradeUnit, svc.ActiveState)
+			u.notify(events.Event{Type: events.TypeUpgradeInfo, Data: u.run.snapshot()})
+		}
 	}
 }

--- a/backend/upgrade/upgrade.go
+++ b/backend/upgrade/upgrade.go
@@ -25,21 +25,25 @@ func New(ctx context.Context, cfg *config.UpgradeConfig, sysd *systemd.SystemdBa
 		return nil, nil
 	}
 
-	// Register as internal before Start, when the listener snapshots the units.
-	if sysd != nil {
-		sysd.AddInternalUserUnits(cfg.CheckUnit, cfg.UpgradeUnit)
-	}
-
-	return &UpgradeBackend{
+	u := &UpgradeBackend{
 		ctx:            ctx,
 		resultFile:     cfg.ResultFile,
 		checkUnit:      cfg.CheckUnit,
 		upgradeUnit:    cfg.UpgradeUnit,
 		progressSocket: cfg.ProgressSocket,
-		systemd:        sysd,
 		run:            newRun(cfg.StateFile),
 		events:         make(chan events.Event, 16),
-	}, nil
+	}
+	// Assigning a nil *SystemdBackend through the interface would make u.systemd
+	// non-nil; only set it for a real backend so the nil checks stay honest.
+	if sysd != nil {
+		// Register as internal before Start, when the listener snapshots the units.
+		sysd.AddInternalUserUnits(cfg.CheckUnit, cfg.UpgradeUnit)
+		u.systemd = sysd
+	}
+	logger.Info("[upgrade] configured: result=%s state=%q socket=%q check=%q upgrade=%q systemd=%t",
+		cfg.ResultFile, cfg.StateFile, cfg.ProgressSocket, cfg.CheckUnit, cfg.UpgradeUnit, sysd != nil)
+	return u, nil
 }
 
 // UseEventStream wires the shared bus; called by Backend.New once the broadcaster exists.

--- a/backend/upgrade/upgrade_test.go
+++ b/backend/upgrade/upgrade_test.go
@@ -163,8 +163,8 @@ func TestInvalidResultKeepsLastValid(t *testing.T) {
 }
 
 // TestStatusResponseShape asserts the GET /upgrade payload: contract fields
-// flat at the top, free fields under "extra", and "run" always present (idle is
-// the last finished verdict, defaulting to success).
+// flat at the top, free fields under "extra", and "run" always present (idle
+// until a run happens).
 func TestStatusResponseShape(t *testing.T) {
 	const result = `{"current":"dev","latest":"2026.7.0","upgrade_available":true,` +
 		`"checked_at":"2026-06-15T20:46:34Z","roles":["common"]}`
@@ -183,7 +183,7 @@ func TestStatusResponseShape(t *testing.T) {
 		return m
 	}
 
-	// Idle: contract fields flat, roles under "extra", run is the finished default.
+	// Idle: contract fields flat, roles under "extra", run is the idle default.
 	m := marshal()
 	if string(m["latest"]) != `"2026.7.0"` {
 		t.Errorf("latest = %s, want flat top-level", m["latest"])
@@ -192,8 +192,8 @@ func TestStatusResponseShape(t *testing.T) {
 	if err := json.Unmarshal(m["run"], &idle); err != nil {
 		t.Fatalf("idle run missing/undecodable: %v", err)
 	}
-	if idle.State != "finished" || idle.Success == nil || !*idle.Success {
-		t.Errorf("idle run = %+v, want finished success=true", idle)
+	if idle.State != "idle" {
+		t.Errorf("idle run = %+v, want state idle", idle)
 	}
 	var extra map[string]json.RawMessage
 	if err := json.Unmarshal(m["extra"], &extra); err != nil {
@@ -311,8 +311,8 @@ func TestBusTerminalStateEmitsFinished(t *testing.T) {
 	if !ok {
 		t.Fatalf("event data = %T, want RunState", e.Data)
 	}
-	if prog.State != "finished" || prog.Success == nil || !*prog.Success {
-		t.Fatalf("got %+v, want state=finished success=true", prog)
+	if prog.State != "idle" {
+		t.Fatalf("got %+v, want state=idle (success)", prog)
 	}
 }
 

--- a/backend/upgrade/upgrade_test.go
+++ b/backend/upgrade/upgrade_test.go
@@ -163,8 +163,8 @@ func TestInvalidResultKeepsLastValid(t *testing.T) {
 }
 
 // TestStatusResponseShape asserts the GET /upgrade payload: contract fields
-// flat at the top, free fields under "extra", and "run" added only while an
-// upgrade is in flight.
+// flat at the top, free fields under "extra", and "run" always present (idle is
+// the last finished verdict, defaulting to success).
 func TestStatusResponseShape(t *testing.T) {
 	const result = `{"current":"dev","latest":"2026.7.0","upgrade_available":true,` +
 		`"checked_at":"2026-06-15T20:46:34Z","roles":["common"]}`
@@ -183,13 +183,17 @@ func TestStatusResponseShape(t *testing.T) {
 		return m
 	}
 
-	// Idle: contract fields flat, roles under "extra", no "run".
+	// Idle: contract fields flat, roles under "extra", run is the finished default.
 	m := marshal()
 	if string(m["latest"]) != `"2026.7.0"` {
 		t.Errorf("latest = %s, want flat top-level", m["latest"])
 	}
-	if _, ok := m["run"]; ok {
-		t.Errorf("idle response should have no run, got %s", m["run"])
+	var idle RunState
+	if err := json.Unmarshal(m["run"], &idle); err != nil {
+		t.Fatalf("idle run missing/undecodable: %v", err)
+	}
+	if idle.State != "finished" || idle.Success == nil || !*idle.Success {
+		t.Errorf("idle run = %+v, want finished success=true", idle)
 	}
 	var extra map[string]json.RawMessage
 	if err := json.Unmarshal(m["extra"], &extra); err != nil {
@@ -199,9 +203,9 @@ func TestStatusResponseShape(t *testing.T) {
 		t.Errorf("extra.roles = %s, want verbatim", extra["roles"])
 	}
 
-	// In flight: "run" appears alongside the flat fields.
-	pct := 50
-	u.runState.Store(&RunState{State: "running", Percent: &pct})
+	// In flight: run reflects the live percent.
+	u.run.start(originSystemd)
+	u.run.progress(50, "installing")
 	var run RunState
 	if err := json.Unmarshal(marshal()["run"], &run); err != nil {
 		t.Fatalf("run missing/undecodable: %v", err)
@@ -293,7 +297,7 @@ func TestBusTerminalStateEmitsFinished(t *testing.T) {
 	recv(t, u.Events(), time.Second) // drain the initial result-read event
 
 	// Simulate an in-progress run, then its unit reaching a terminal success state.
-	u.running.Store(true)
+	u.run.start(originSystemd)
 	stream.ch <- events.Event{
 		Type: events.TypeServiceUpdated,
 		Data: systemd.Service{Name: "odio-upgrade.service", Scope: systemd.ScopeUser, ActiveState: "inactive"},

--- a/config/config.go
+++ b/config/config.go
@@ -102,6 +102,7 @@ type SystemdConfig struct {
 type UpgradeConfig struct {
 	Enabled        bool
 	ResultFile     string // upgrades.json to read and watch
+	StateFile      string // run-state snapshot, persisted across restarts
 	CheckUnit      string // user unit to (re)run detection; empty disables /upgrade/check
 	UpgradeUnit    string // user unit to run the upgrade; empty disables /upgrade/start
 	ProgressSocket string // unix socket the upgrade script streams run progress to
@@ -350,9 +351,19 @@ func New(cfgFile *string) (*Config, error) {
 	if progressSocket == "" {
 		progressSocket = filepath.Join(xdgRuntimeDir, "odio-api", "upgrade.sock")
 	}
+	// The run-state snapshot must survive a machine reboot, so it lives in the
+	// cache dir, not the tmpfs runtime dir.
+	stateFile := viper.GetString("upgrade.stateFile")
+	if stateFile == "" {
+		cacheDir, err := os.UserCacheDir()
+		if err == nil {
+			stateFile = filepath.Join(cacheDir, "odio-api", "upgrade-run.json")
+		}
+	}
 	upgradecfg := UpgradeConfig{
 		Enabled:        viper.GetBool("upgrade.enabled"),
 		ResultFile:     viper.GetString("upgrade.resultFile"),
+		StateFile:      stateFile,
 		CheckUnit:      viper.GetString("upgrade.checkUnit"),
 		UpgradeUnit:    viper.GetString("upgrade.upgradeUnit"),
 		ProgressSocket: progressSocket,

--- a/ui/handler_test.go
+++ b/ui/handler_test.go
@@ -245,6 +245,53 @@ func TestUpgradeBadgeRunning(t *testing.T) {
 	}
 }
 
+func TestUpgradeBadgeFailed(t *testing.T) {
+	tmpl := LoadTemplates()
+
+	render := func(status *UpgradeStatus) string {
+		t.Helper()
+		var buf bytes.Buffer
+		if err := tmpl.ExecuteTemplate(&buf, "section-upgrade", status); err != nil {
+			t.Fatalf("execute section-upgrade: %v", err)
+		}
+		return buf.String()
+	}
+
+	// A failed verdict wins over UpgradeAvailable: the alert icon shows by
+	// default and swaps to the green upgrade arrow on hover, with a retry button.
+	out := render(&UpgradeStatus{
+		Latest: "1.1", UpgradeAvailable: true, CanUpgrade: true,
+		Run: &UpgradeRun{State: "failed"},
+	})
+	if !strings.Contains(out, "m21.73 18-8-14") {
+		t.Errorf("failed badge should show the alert icon, got: %s", out)
+	}
+	if !strings.Contains(out, "group-hover:hidden") || !strings.Contains(out, "group-hover:inline-flex") {
+		t.Errorf("failed badge should swap icons on hover, got: %s", out)
+	}
+	if !strings.Contains(out, "M12 19V5") {
+		t.Errorf("failed badge should reveal the upgrade arrow on hover, got: %s", out)
+	}
+	if !strings.Contains(out, `hx-post="/upgrade/start"`) || !strings.Contains(out, "hx-confirm=") {
+		t.Errorf("failed badge with trigger should retry the upgrade, got: %s", out)
+	}
+
+	// Without the trigger it is a static indicator, no click action.
+	gated := render(&UpgradeStatus{Latest: "1.1", Run: &UpgradeRun{State: "failed"}})
+	if strings.Contains(gated, "hx-post=") {
+		t.Errorf("failed badge without trigger must not be clickable, got: %s", gated)
+	}
+	if !strings.Contains(gated, "m21.73 18-8-14") {
+		t.Errorf("failed badge without trigger should still show the alert icon, got: %s", gated)
+	}
+
+	// A succeeded run is idle, not a failure: no alert icon.
+	ok := render(&UpgradeStatus{Latest: "1.0", Run: &UpgradeRun{State: "idle"}})
+	if strings.Contains(ok, "m21.73 18-8-14") {
+		t.Errorf("succeeded (idle) run must not show the alert icon, got: %s", ok)
+	}
+}
+
 // TestUpgradeBadgeGatedActions verifies the badge renders a static icon (no
 // hx-post) when the matching trigger is unavailable, e.g. result-file-only mode.
 func TestUpgradeBadgeGatedActions(t *testing.T) {

--- a/ui/sse_test.go
+++ b/ui/sse_test.go
@@ -163,6 +163,55 @@ func TestSSEEvents_DebounceCoalesces(t *testing.T) {
 	}
 }
 
+// TestSSEEvents_UpgradeFailedRendersFailBadge locks the end-to-end failed path:
+// an upgrade.info event re-fetches GET /upgrade, and a run in the "failed" state
+// must render the alert-icon fail badge.
+func TestSSEEvents_UpgradeFailedRendersFailBadge(t *testing.T) {
+	upstream := make(chan events.Event, 4)
+	b := backend.NewBroadcaster(context.Background(), upstream)
+
+	apiMux := http.NewServeMux()
+	apiMux.HandleFunc("/upgrade", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := w.Write([]byte(`{"current":"1.0","latest":"1.1","upgrade_available":true,` +
+			`"can_upgrade":true,"run":{"state":"failed"}}`)); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+	})
+	apiServer := httptest.NewServer(apiMux)
+	defer apiServer.Close()
+
+	h := &Handler{
+		tmpl:        LoadTemplates(),
+		client:      NewAPIClient(testAPIPort(t, apiServer)),
+		broadcaster: b,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	req := httptest.NewRequest(http.MethodGet, "/ui/events", nil).WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		h.SSEEvents(w, req)
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+	upstream <- events.Event{Type: events.TypeUpgradeInfo, Data: "test"}
+	time.Sleep(350 * time.Millisecond)
+	cancel()
+	<-done
+
+	body := w.Body.String()
+	if !strings.Contains(body, "event: section-upgrade") {
+		t.Fatalf("expected a section-upgrade SSE event, got: %s", body)
+	}
+	if !strings.Contains(body, "m21.73 18-8-14") {
+		t.Errorf("failed run should render the alert-icon fail badge, got: %s", body)
+	}
+}
+
 func TestSSEEvents_EventMapping(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/ui/templates/components/icons.gohtml
+++ b/ui/templates/components/icons.gohtml
@@ -41,3 +41,5 @@
 {{ define "icon-check" }}<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>{{ end }}
 
 {{ define "icon-arrow-up" }}<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m5 12 7-7 7 7"/><path d="M12 19V5"/></svg>{{ end }}
+
+{{ define "icon-triangle-alert" }}<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z"/><path d="M12 9v4"/><path d="M12 17h.01"/></svg>{{ end }}

--- a/ui/templates/components/upgrade_badge.gohtml
+++ b/ui/templates/components/upgrade_badge.gohtml
@@ -12,6 +12,8 @@
 	      sse-swap="upgrade-progress" hx-swap="innerHTML">
 		{{ template "upgrade-ring" .Run }}
 	</span>
+{{- else if .Failed -}}
+	{{ template "upgrade-fail" (dict "Status" . "Base" $base) }}
 {{- else if and .Known .UpgradeAvailable -}}
 	{{ template "upgrade-start" (dict "Status" . "Base" $base) }}
 {{- else -}}

--- a/ui/templates/components/upgrade_badge_parts.gohtml
+++ b/ui/templates/components/upgrade_badge_parts.gohtml
@@ -35,6 +35,26 @@
 
 {{ define "upgrade-check-icon" }}{{ if .Known }}{{ template "icon-check" }}{{ else }}{{ template "icon-rotate-cw" }}{{ end }}{{ end }}
 
+{{/* Last run failed: red alert icon that swaps to the green upgrade arrow on
+     hover. A button retries the upgrade when the trigger is available, else a
+     static indicator with the same look. */}}
+{{ define "upgrade-fail" }}
+{{- $s := .Status -}}
+{{- if $s.Upgradeable -}}
+<button hx-post="/upgrade/start" hx-swap="none" hx-confirm="Retry upgrade to {{ $s.Latest }}?"
+        class="group {{ .Base }} bg-red-500/10 text-red-400 transition hover:bg-green-500/10 hover:text-green-400"
+        title="Upgrade failed — retry">{{ template "upgrade-fail-icons" }}</button>
+{{- else -}}
+<span class="group {{ .Base }} bg-red-500/10 text-red-400 transition hover:bg-green-500/10 hover:text-green-400"
+      title="Upgrade failed">{{ template "upgrade-fail-icons" }}</span>
+{{- end -}}
+{{ end }}
+
+{{ define "upgrade-fail-icons" -}}
+<span class="group-hover:hidden">{{ template "icon-triangle-alert" }}</span>
+<span class="hidden group-hover:inline-flex">{{ template "icon-arrow-up" }}</span>
+{{- end }}
+
 {{/* Progress ring; data is *ui.UpgradeRun (may be nil). Spinner until a percent is streamed. */}}
 {{ define "upgrade-ring" }}
 {{- if .HasPercent -}}

--- a/ui/types.go
+++ b/ui/types.go
@@ -47,9 +47,10 @@ type UpgradeStatus struct {
 	CanUpgrade       bool        `json:"can_upgrade"`
 }
 
-// UpgradeRun is the live progress of an in-flight upgrade; nil unless one runs.
-// Percent is nil until the script streams it (e.g. after an odio-api restart
-// mid-run), which the badge shows as an indeterminate ring.
+// UpgradeRun is the run snapshot: the verdict is the state itself — "idle"
+// (none or last succeeded), "running", or "failed". Percent is nil until the
+// script streams it (e.g. after an odio-api restart mid-run), which the badge
+// shows as an indeterminate ring.
 type UpgradeRun struct {
 	State   string `json:"state"`
 	Percent *int   `json:"percent"`
@@ -76,6 +77,12 @@ func (u *UpgradeStatus) Known() bool {
 // Running reports whether an upgrade is in flight.
 func (u *UpgradeStatus) Running() bool {
 	return u != nil && u.Run != nil && u.Run.State == "running"
+}
+
+// Failed reports whether the last run ended unsuccessfully. The badge shows it
+// until the next run, which lets the user retry.
+func (u *UpgradeStatus) Failed() bool {
+	return u != nil && u.Run != nil && u.Run.State == "failed"
 }
 
 // Checkable / Upgradeable report whether the matching trigger is available, so


### PR DESCRIPTION
Replace the running atomic.Bool / runState cache pair with a single `run` state machine that owns the upgrade lifecycle, tracks its origin, and survives a restart.

Motivation:
- The two pieces of state (an in-flight flag and a separate progress snapshot) could drift, and neither survived a process restart, so a reboot mid-upgrade lost the run entirely.
- Upgrades launched outside the systemd unit (a CLI client streaming over the progress socket) had no way to surface in the UI.

Changes:
- backend/upgrade/run.go: new `run` type, the single source of truth. start/begin/progress/finish/snapshot guard concurrency and advance state under one mutex. finish is idempotent so the socket "end" line and the unit's terminal state can race and still emit finished exactly once.
- Persist the run snapshot across restarts: load() on Start, save() on Close, written atomically to a cache-dir state file. Progress is kept in memory and only flushed on shutdown to avoid hammering the SD card on a Pi; a SIGKILL loses the in-memory percent, reconciled at next boot.
- Track run Origin ("systemd" | "socket"). A socket-origin run owns its own lifecycle and is closed by its "end" line, not by the unit; it resumes by awaiting client reconnect rather than consulting systemd.
- resumeIfRunning reconciles a restored or out-of-band run at startup: still-activating resumes, already-terminal records the verdict missed while we were down.
- RunState is now never nil: idle is the last finished verdict (defaulting to success), so clients no longer special-case an absent run. Add Origin, StartedAt and FinishedAt fields. GET /upgrade always carries "run".
- A failed unit trigger now records a failure verdict instead of rewinding to idle, so the UI shows the failure.
- config: add UpgradeConfig.StateFile, defaulting under the user cache dir (not the tmpfs runtime dir) so it survives a reboot.
- Update tests to drive the new run API and assert "run" is always present.