### PR TITLE
feat(mpris): load TrackList state into the player cache

### DIFF
--- a/api/handlers_mpris_test.go
+++ b/api/handlers_mpris_test.go
@@ -179,6 +179,14 @@ func TestHandleMPRISError(t *testing.T) {
 			wantBodyMatch:  "action not allowed",
 		},
 		{
+			name: "TracklistUnsupportedError returns 404 Not Found",
+			err: &mpris.TracklistUnsupportedError{
+				BusName: "org.mpris.MediaPlayer2.firefox",
+			},
+			wantStatusCode: http.StatusNotFound,
+			wantBodyMatch:  "tracklist not supported",
+		},
+		{
 			name:           "generic error returns 500 Internal Server Error",
 			err:            http.ErrServerClosed,
 			wantStatusCode: http.StatusInternalServerError,
@@ -203,6 +211,114 @@ func TestHandleMPRISError(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestTracklistHandler(t *testing.T) {
+	tests := []struct {
+		name           string
+		getTracklist   func(string) (*mpris.TracklistResponse, error)
+		wantStatusCode int
+		wantBodyMatch  string
+	}{
+		{
+			name: "success returns 200 with tracks",
+			getTracklist: func(string) (*mpris.TracklistResponse, error) {
+				return &mpris.TracklistResponse{
+					CanEditTracks: true,
+					Tracks:        []mpris.Track{{TrackID: "/org/mpris/MediaPlayer2/Track/1"}},
+				}, nil
+			},
+			wantStatusCode: http.StatusOK,
+			wantBodyMatch:  `"/org/mpris/MediaPlayer2/Track/1"`,
+		},
+		{
+			name: "empty tracklist returns 200 with empty array",
+			getTracklist: func(string) (*mpris.TracklistResponse, error) {
+				return &mpris.TracklistResponse{Tracks: []mpris.Track{}}, nil
+			},
+			wantStatusCode: http.StatusOK,
+			wantBodyMatch:  `"tracks":[]`,
+		},
+		{
+			name: "unsupported returns 404",
+			getTracklist: func(busName string) (*mpris.TracklistResponse, error) {
+				return nil, &mpris.TracklistUnsupportedError{BusName: busName}
+			},
+			wantStatusCode: http.StatusNotFound,
+			wantBodyMatch:  "tracklist not supported",
+		},
+		{
+			name: "player not found returns 404",
+			getTracklist: func(busName string) (*mpris.TracklistResponse, error) {
+				return nil, &mpris.PlayerNotFoundError{BusName: busName}
+			},
+			wantStatusCode: http.StatusNotFound,
+			wantBodyMatch:  "player not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := TracklistHandler(tt.getTracklist)
+
+			req := httptest.NewRequest("GET", "/players/org.mpris.MediaPlayer2.mpd/tracklist", nil)
+			req.SetPathValue("player", "org.mpris.MediaPlayer2.mpd")
+			w := httptest.NewRecorder()
+
+			handler(w, req)
+
+			if w.Code != tt.wantStatusCode {
+				t.Errorf("status = %d, want %d", w.Code, tt.wantStatusCode)
+			}
+			if !strings.Contains(w.Body.String(), tt.wantBodyMatch) {
+				t.Errorf("body = %q, want to contain %q", w.Body.String(), tt.wantBodyMatch)
+			}
+		})
+	}
+}
+
+func TestWithTrackRoutePattern(t *testing.T) {
+	newMux := func(gotBus, gotTrack *string) *http.ServeMux {
+		mux := http.NewServeMux()
+		mux.HandleFunc("POST /players/{player}/tracklist/goto/{trackid}",
+			withTrack(func(w http.ResponseWriter, r *http.Request, busName, trackRef string) {
+				*gotBus, *gotTrack = busName, trackRef
+				w.WriteHeader(http.StatusAccepted)
+			}))
+		return mux
+	}
+
+	t.Run("last segment", func(t *testing.T) {
+		var gotBus, gotTrack string
+		req := httptest.NewRequest("POST", "/players/org.mpris.MediaPlayer2.mpd/tracklist/goto/7", nil)
+		w := httptest.NewRecorder()
+		newMux(&gotBus, &gotTrack).ServeHTTP(w, req)
+
+		if w.Code != http.StatusAccepted {
+			t.Fatalf("status = %d, want %d", w.Code, http.StatusAccepted)
+		}
+		if gotBus != "org.mpris.MediaPlayer2.mpd" {
+			t.Errorf("busName = %q, want %q", gotBus, "org.mpris.MediaPlayer2.mpd")
+		}
+		if gotTrack != "7" {
+			t.Errorf("trackRef = %q, want %q", gotTrack, "7")
+		}
+	})
+
+	t.Run("percent-encoded full object path", func(t *testing.T) {
+		var gotBus, gotTrack string
+		req := httptest.NewRequest("POST",
+			"/players/org.mpris.MediaPlayer2.mpd/tracklist/goto/%2Forg%2Fmpris%2FMediaPlayer2%2FTrack%2F7", nil)
+		w := httptest.NewRecorder()
+		newMux(&gotBus, &gotTrack).ServeHTTP(w, req)
+
+		if w.Code != http.StatusAccepted {
+			t.Fatalf("status = %d, want %d", w.Code, http.StatusAccepted)
+		}
+		if gotTrack != "/org/mpris/MediaPlayer2/Track/7" {
+			t.Errorf("trackRef = %q, want %q", gotTrack, "/org/mpris/MediaPlayer2/Track/7")
+		}
+	})
 }
 
 // TestWithPlayer tests the middleware for extracting busName

--- a/api/players.go
+++ b/api/players.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/url"
@@ -43,6 +44,13 @@ func handleMPRISError(w http.ResponseWriter, err error) {
 	// Handle player not found errors
 	var notFoundErr *mpris.PlayerNotFoundError
 	if errors.As(err, &notFoundErr) {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+
+	// Tracklist unsupported: the resource doesn't exist for this player
+	var unsupportedErr *mpris.TracklistUnsupportedError
+	if errors.As(err, &unsupportedErr) {
 		http.Error(w, err.Error(), http.StatusNotFound)
 		return
 	}
@@ -131,6 +139,52 @@ func SetShuffleHandler(m *mpris.MPRISBackend) http.HandlerFunc {
 	return withPlayer(func(w http.ResponseWriter, r *http.Request, busName string) {
 		withBody(nil, func(w http.ResponseWriter, r *http.Request, req *mpris.ShuffleRequest) {
 			handleMPRISError(w, m.SetShuffle(busName, req.Shuffle))
+		})(w, r)
+	})
+}
+
+// withTrack extracts the {trackid} parameter: the last segment of a track's
+// object path (or the %2F-encoded full path), resolved against the cached
+// tracklist by the backend.
+func withTrack(
+	next func(w http.ResponseWriter, r *http.Request, busName, trackRef string),
+) http.HandlerFunc {
+	return withPlayer(func(w http.ResponseWriter, r *http.Request, busName string) {
+		next(w, r, busName, r.PathValue("trackid"))
+	})
+}
+
+func TracklistHandler(getTracklist func(string) (*mpris.TracklistResponse, error)) http.HandlerFunc {
+	return withPlayer(func(w http.ResponseWriter, r *http.Request, busName string) {
+		resp, err := getTracklist(busName)
+		if err != nil {
+			handleMPRISError(w, err)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+	})
+}
+
+func GoToHandler(m *mpris.MPRISBackend) http.HandlerFunc {
+	return withTrack(func(w http.ResponseWriter, r *http.Request, busName, trackID string) {
+		handleMPRISError(w, m.GoTo(busName, trackID))
+	})
+}
+
+func RemoveTrackHandler(m *mpris.MPRISBackend) http.HandlerFunc {
+	return withTrack(func(w http.ResponseWriter, r *http.Request, busName, trackID string) {
+		handleMPRISError(w, m.RemoveTrack(busName, trackID))
+	})
+}
+
+func AddTrackHandler(m *mpris.MPRISBackend) http.HandlerFunc {
+	return withPlayer(func(w http.ResponseWriter, r *http.Request, busName string) {
+		withBody(nil, func(w http.ResponseWriter, r *http.Request, req *mpris.AddTrackRequest) {
+			handleMPRISError(w, m.AddTrack(busName, req.Uri, req.AfterTrack, req.SetAsCurrent))
 		})(w, r)
 	})
 }

--- a/api/routes.go
+++ b/api/routes.go
@@ -230,4 +230,20 @@ func (s *Server) registerMPRISRoutes(b *mpris.MPRISBackend) {
 		"POST /players/{player}/shuffle",
 		SetShuffleHandler(b),
 	)
+	s.mux.HandleFunc(
+		"GET /players/{player}/tracklist",
+		TracklistHandler(b.GetTracklist),
+	)
+	s.mux.HandleFunc(
+		"POST /players/{player}/tracklist/goto/{trackid}",
+		GoToHandler(b),
+	)
+	s.mux.HandleFunc(
+		"POST /players/{player}/tracklist/add",
+		AddTrackHandler(b),
+	)
+	s.mux.HandleFunc(
+		"POST /players/{player}/tracklist/remove/{trackid}",
+		RemoveTrackHandler(b),
+	)
 }

--- a/backend/mpris/consts.go
+++ b/backend/mpris/consts.go
@@ -1,8 +1,6 @@
 package mpris
 
 const (
-	CACHE_KEY = "players"
-
 	// MPRIS D-Bus constants
 	MPRIS_PREFIX    = "org.mpris.MediaPlayer2"
 	MPRIS_PATH      = "/org/mpris/MediaPlayer2"

--- a/backend/mpris/consts.go
+++ b/backend/mpris/consts.go
@@ -4,10 +4,12 @@ const (
 	CACHE_KEY = "players"
 
 	// MPRIS D-Bus constants
-	MPRIS_PREFIX       = "org.mpris.MediaPlayer2"
-	MPRIS_PATH         = "/org/mpris/MediaPlayer2"
-	MPRIS_INTERFACE    = "org.mpris.MediaPlayer2"
-	MPRIS_PLAYER_IFACE = "org.mpris.MediaPlayer2.Player"
+	MPRIS_PREFIX    = "org.mpris.MediaPlayer2"
+	MPRIS_PATH      = "/org/mpris/MediaPlayer2"
+	MPRIS_INTERFACE = "org.mpris.MediaPlayer2"
+
+	MPRIS_PLAYER_IFACE    = MPRIS_PREFIX + ".Player"
+	MPRIS_TRACKLIST_IFACE = MPRIS_PREFIX + ".TrackList"
 
 	// D-Bus system constants
 	DBUS_INTERFACE  = "org.freedesktop.DBus"
@@ -32,6 +34,18 @@ const (
 	MPRIS_METHOD_PREVIOUS     = MPRIS_PLAYER_IFACE + ".Previous"
 	MPRIS_METHOD_SEEK         = MPRIS_PLAYER_IFACE + ".Seek"
 	MPRIS_METHOD_SET_POSITION = MPRIS_PLAYER_IFACE + ".SetPosition"
+
+	// MPRIS TrackList methods
+	MPRIS_METHOD_GET_TRACKS_METADATA = MPRIS_TRACKLIST_IFACE + ".GetTracksMetadata"
+	MPRIS_METHOD_ADD_TRACK           = MPRIS_TRACKLIST_IFACE + ".AddTrack"
+	MPRIS_METHOD_REMOVE_TRACK        = MPRIS_TRACKLIST_IFACE + ".RemoveTrack"
+	MPRIS_METHOD_GO_TO               = MPRIS_TRACKLIST_IFACE + ".GoTo"
+
+	// MPRIS TrackList signals
+	MPRIS_SIGNAL_TRACKLIST_REPLACED     = MPRIS_TRACKLIST_IFACE + ".TrackListReplaced"
+	MPRIS_SIGNAL_TRACK_ADDED            = MPRIS_TRACKLIST_IFACE + ".TrackAdded"
+	MPRIS_SIGNAL_TRACK_REMOVED          = MPRIS_TRACKLIST_IFACE + ".TrackRemoved"
+	MPRIS_SIGNAL_TRACK_METADATA_CHANGED = MPRIS_TRACKLIST_IFACE + ".TrackMetadataChanged"
 )
 
 // MPRIS_NO_TRACK is the well-known track ID meaning "no current track".

--- a/backend/mpris/dbus.go
+++ b/backend/mpris/dbus.go
@@ -134,43 +134,10 @@ func arg[T any](sig *dbus.Signal, i int) (T, bool) {
 	return v, ok
 }
 
-// Value extraction helpers from dbus.Variant
-// These helpers are used to extract values from variants received
-// in D-Bus signals without making additional D-Bus calls.
-
-// extractString extracts a string from a dbus.Variant
-func extractString(v dbus.Variant) (string, bool) {
-	val, ok := v.Value().(string)
-	return val, ok
-}
-
-// extractBool extracts a bool from a dbus.Variant
-func extractBool(v dbus.Variant) (bool, bool) {
-	val, ok := v.Value().(bool)
-	return val, ok
-}
-
-// extractInt64 extracts an int64 from a dbus.Variant
-func extractInt64(v dbus.Variant) (int64, bool) {
-	val, ok := v.Value().(int64)
-	return val, ok
-}
-
-// extractFloat64 extracts a float64 from a dbus.Variant
-func extractFloat64(v dbus.Variant) (float64, bool) {
-	val, ok := v.Value().(float64)
-	return val, ok
-}
-
-// extractStringSlice extracts a []string from a dbus.Variant
-func extractStringSlice(v dbus.Variant) ([]string, bool) {
-	val, ok := v.Value().([]string)
-	return val, ok
-}
-
-// extractMetadataMap extracts a metadata map from a dbus.Variant
-func extractMetadataMap(v dbus.Variant) (map[string]dbus.Variant, bool) {
-	val, ok := v.Value().(map[string]dbus.Variant)
+// extract returns the variant's value as T, false if it holds another type.
+// Lets signal handlers read values without additional D-Bus calls.
+func extract[T any](v dbus.Variant) (T, bool) {
+	val, ok := v.Value().(T)
 	return val, ok
 }
 

--- a/backend/mpris/dbus.go
+++ b/backend/mpris/dbus.go
@@ -89,8 +89,8 @@ func (m *MPRISBackend) addMatchRule(rule string) error {
 }
 
 // addListenMatchRules subscribes to the necessary D-Bus signals for the listener.
-// Subscribes to PropertiesChanged (player state changes) and
-// NameOwnerChanged (player appearance/disappearance).
+// Subscribes to PropertiesChanged (player state changes),
+// NameOwnerChanged (player appearance/disappearance) and TrackList signals.
 func (m *MPRISBackend) addListenMatchRules() error {
 	matchRule := "type='signal',interface='" + DBUS_PROP_IFACE + "',member='PropertiesChanged',arg0namespace='" + MPRIS_PREFIX + "'"
 	if err := m.addMatchRule(matchRule); err != nil {
@@ -99,6 +99,13 @@ func (m *MPRISBackend) addListenMatchRules() error {
 
 	ownerMatchRule := "type='signal',interface='" + DBUS_INTERFACE + "',member='NameOwnerChanged',arg0namespace='" + MPRIS_PREFIX + "'"
 	if err := m.addMatchRule(ownerMatchRule); err != nil {
+		return err
+	}
+
+	// No arg0namespace here: TrackListReplaced's arg0 is `ao`, not a string.
+	// Unknown senders at this path are dropped by findPlayerByUniqueName.
+	tracklistMatchRule := "type='signal',interface='" + MPRIS_TRACKLIST_IFACE + "',path='" + MPRIS_PATH + "'"
+	if err := m.addMatchRule(tracklistMatchRule); err != nil {
 		return err
 	}
 
@@ -168,4 +175,19 @@ func (p *Player) getAllProperties(iface string) (map[string]dbus.Variant, error)
 
 	err := call.Store(&props)
 	return props, err
+}
+
+// getTracksMetadata retrieves metadata for the given track IDs in a single call.
+// The spec guarantees results in the same order as the requested IDs.
+func (p *Player) getTracksMetadata(ids []dbus.ObjectPath) ([]map[string]dbus.Variant, error) {
+	obj := p.conn.Object(p.BusName, MPRIS_PATH)
+	var metas []map[string]dbus.Variant
+
+	call := obj.Call(MPRIS_METHOD_GET_TRACKS_METADATA, 0, ids)
+	if err := p.callWithTimeout(call); err != nil {
+		return nil, err
+	}
+
+	err := call.Store(&metas)
+	return metas, err
 }

--- a/backend/mpris/dbus.go
+++ b/backend/mpris/dbus.go
@@ -124,6 +124,16 @@ func (m *MPRISBackend) getNameOwner(busName string) (string, error) {
 	return owner, nil
 }
 
+// arg extracts sig.Body[i] as T, false if absent or mistyped.
+func arg[T any](sig *dbus.Signal, i int) (T, bool) {
+	if i >= len(sig.Body) {
+		var zero T
+		return zero, false
+	}
+	v, ok := sig.Body[i].(T)
+	return v, ok
+}
+
 // Value extraction helpers from dbus.Variant
 // These helpers are used to extract values from variants received
 // in D-Bus signals without making additional D-Bus calls.

--- a/backend/mpris/dbus.go
+++ b/backend/mpris/dbus.go
@@ -162,6 +162,12 @@ func extractFloat64(v dbus.Variant) (float64, bool) {
 	return val, ok
 }
 
+// extractStringSlice extracts a []string from a dbus.Variant
+func extractStringSlice(v dbus.Variant) ([]string, bool) {
+	val, ok := v.Value().([]string)
+	return val, ok
+}
+
 // extractMetadataMap extracts a metadata map from a dbus.Variant
 func extractMetadataMap(v dbus.Variant) (map[string]dbus.Variant, bool) {
 	val, ok := v.Value().(map[string]dbus.Variant)

--- a/backend/mpris/errors.go
+++ b/backend/mpris/errors.go
@@ -41,6 +41,15 @@ func (e *ValidationError) Error() string {
 	return e.Message
 }
 
+// TracklistUnsupportedError indicates that a player doesn't implement the TrackList interface
+type TracklistUnsupportedError struct {
+	BusName string
+}
+
+func (e *TracklistUnsupportedError) Error() string {
+	return "tracklist not supported: " + e.BusName
+}
+
 type dbusTimeoutError struct{}
 
 func (e *dbusTimeoutError) Error() string {

--- a/backend/mpris/heartbeat.go
+++ b/backend/mpris/heartbeat.go
@@ -87,8 +87,8 @@ func (h *Heartbeat) run() {
 // updatePlayingPositions updates the position of all playing players.
 // Returns true if at least one player is Playing.
 func (h *Heartbeat) updatePlayingPositions() bool {
-	players, ok := h.backend.cache.Get(CACHE_KEY)
-	if !ok {
+	players := h.backend.players.Load()
+	if players == nil {
 		return false
 	}
 

--- a/backend/mpris/heartbeat.go
+++ b/backend/mpris/heartbeat.go
@@ -108,7 +108,7 @@ func (h *Heartbeat) updatePlayingPositions() bool {
 			continue
 		}
 
-		pos, ok := extractInt64(variant)
+		pos, ok := extract[int64](variant)
 		if !ok || !shouldAcceptPosition(&player, pos) {
 			continue
 		}

--- a/backend/mpris/listener.go
+++ b/backend/mpris/listener.go
@@ -124,7 +124,7 @@ func (l *Listener) handlePropertiesChanged(sig *dbus.Signal) {
 
 	// Check if PlaybackStatus changed for deduplication
 	if statusVar, hasStatus := changed["PlaybackStatus"]; hasStatus {
-		if status, ok := extractString(statusVar); ok {
+		if status, ok := extract[string](statusVar); ok {
 			newStatus := PlaybackStatus(status)
 
 			// Deduplication

--- a/backend/mpris/listener.go
+++ b/backend/mpris/listener.go
@@ -2,6 +2,7 @@ package mpris
 
 import (
 	"context"
+	"slices"
 	"strings"
 
 	"github.com/godbus/dbus/v5"
@@ -62,6 +63,11 @@ func (l *Listener) handleSignal(sig *dbus.Signal) {
 		l.handlePropertiesChanged(sig)
 	case DBUS_NAME_OWNER_CHANGED:
 		l.handleNameOwnerChanged(sig)
+	case MPRIS_SIGNAL_TRACKLIST_REPLACED, MPRIS_SIGNAL_TRACK_ADDED,
+		MPRIS_SIGNAL_TRACK_REMOVED, MPRIS_SIGNAL_TRACK_METADATA_CHANGED:
+		if busName := l.resolveSender(sig); busName != "" {
+			l.handleTrackListSignal(busName, sig)
+		}
 	default:
 		logger.Debug("[mpris] unhandled signal: %s", sig.Name)
 	}
@@ -73,17 +79,12 @@ func (l *Listener) handlePropertiesChanged(sig *dbus.Signal) {
 	// Body[1] = changed properties (map[string]Variant)
 	// Body[2] = invalidated properties ([]string)
 
-	if len(sig.Body) < 2 {
+	iface, ok := arg[string](sig, 0)
+	if !ok {
 		return
 	}
 
-	iface, ok := sig.Body[0].(string)
-	if !ok || iface != MPRIS_PLAYER_IFACE {
-		// We only care about Player changes
-		return
-	}
-
-	changed, ok := sig.Body[1].(map[string]dbus.Variant)
+	changed, ok := arg[map[string]dbus.Variant](sig, 1)
 	if !ok {
 		return
 	}
@@ -93,6 +94,31 @@ func (l *Listener) handlePropertiesChanged(sig *dbus.Signal) {
 	busName := l.backend.findPlayerByUniqueName(sig.Sender)
 	if busName == "" {
 		// Signal from unknown player, ignore
+		return
+	}
+
+	if iface == MPRIS_TRACKLIST_IFACE {
+		if v, ok := changed["CanEditTracks"]; ok {
+			if err := l.backend.UpdateCanEditTracks(busName, v); err != nil {
+				logger.Error("[mpris] failed to update CanEditTracks for %s: %v", busName, err)
+			}
+		}
+		// Some players (VLC) never emit usable TrackList signals (VLC mangles
+		// their interface name) and only report queue changes here — as a
+		// changed value or a bare invalidation. Skipping when the IDs match
+		// the cache keeps players that emit both from doubling up.
+		if v, ok := changed["Tracks"]; ok {
+			if ids, ok := v.Value().([]dbus.ObjectPath); ok && !l.backend.tracklistMatches(busName, ids) {
+				l.refreshTracklist(busName, ids)
+			}
+			return
+		}
+		if invalidated, ok := arg[[]string](sig, 2); ok && slices.Contains(invalidated, "Tracks") {
+			l.refetchTracklist(busName)
+		}
+		return
+	}
+	if iface != MPRIS_PLAYER_IFACE {
 		return
 	}
 
@@ -175,6 +201,124 @@ func (l *Listener) handleNameOwnerChanged(sig *dbus.Signal) {
 		if err := l.backend.RemovePlayer(busName); err != nil {
 			logger.Error("[mpris] failed to remove player %s: %v", busName, err)
 		}
+	}
+}
+
+// resolveSender maps a signal's unique-name sender to a cached busName.
+// Dropping unknown senders is the safety net for the broad interface+path
+// match rule, which delivers TrackList signals from any sender.
+func (l *Listener) resolveSender(sig *dbus.Signal) string {
+	busName := l.backend.findPlayerByUniqueName(sig.Sender)
+	if busName == "" {
+		logger.Debug("[mpris] dropping %s from unknown sender %s", sig.Name, sig.Sender)
+	}
+	return busName
+}
+
+// refreshTracklist replaces a player's cached tracklist from a list of IDs,
+// fetching their metadata in one call (IDs only on failure).
+func (l *Listener) refreshTracklist(busName string, ids []dbus.ObjectPath) {
+	tracks := tracksFromIDs(ids)
+	if len(ids) > 0 {
+		if metas, err := newPlayer(l.backend, busName).getTracksMetadata(ids); err == nil {
+			tracks = tracksFromMetadata(ids, metas)
+		} else {
+			logger.Debug("[mpris] GetTracksMetadata failed for %s, keeping IDs only: %v", busName, err)
+		}
+	}
+
+	if err := l.backend.ReplaceTracklist(busName, tracks); err != nil {
+		logger.Error("[mpris] failed to replace tracklist for %s: %v", busName, err)
+	}
+}
+
+// refetchTracklist re-reads the Tracks property after an invalidation
+// (no value in the signal) and refreshes the cache if it changed.
+func (l *Listener) refetchTracklist(busName string) {
+	v, err := l.backend.getProperty(busName, MPRIS_TRACKLIST_IFACE, "Tracks")
+	if err != nil {
+		logger.Debug("[mpris] failed to fetch Tracks for %s: %v", busName, err)
+		return
+	}
+	ids, ok := v.Value().([]dbus.ObjectPath)
+	if !ok {
+		return
+	}
+	if !l.backend.tracklistMatches(busName, ids) {
+		l.refreshTracklist(busName, ids)
+	}
+}
+
+// handleTrackListSignal dispatches TrackList signals once the sender is
+// resolved to a cached player.
+func (l *Listener) handleTrackListSignal(busName string, sig *dbus.Signal) {
+	switch sig.Name {
+	case MPRIS_SIGNAL_TRACKLIST_REPLACED:
+		l.handleTrackListReplaced(busName, sig)
+	case MPRIS_SIGNAL_TRACK_ADDED:
+		l.handleTrackAdded(busName, sig)
+	case MPRIS_SIGNAL_TRACK_REMOVED:
+		l.handleTrackRemoved(busName, sig)
+	case MPRIS_SIGNAL_TRACK_METADATA_CHANGED:
+		l.handleTrackMetadataChanged(busName, sig)
+	}
+}
+
+// handleTrackListReplaced processes a wholesale tracklist replacement.
+// Body[0] = new track IDs; Body[1] = current track (unused)
+func (l *Listener) handleTrackListReplaced(busName string, sig *dbus.Signal) {
+	ids, ok := arg[[]dbus.ObjectPath](sig, 0)
+	if !ok {
+		return
+	}
+
+	l.refreshTracklist(busName, ids)
+}
+
+// handleTrackAdded processes a track insertion.
+// Body[0] = track metadata; Body[1] = the track it was inserted after
+func (l *Listener) handleTrackAdded(busName string, sig *dbus.Signal) {
+	meta, ok := arg[map[string]dbus.Variant](sig, 0)
+	if !ok {
+		return
+	}
+	afterTrack, ok := arg[dbus.ObjectPath](sig, 1)
+	if !ok {
+		return
+	}
+
+	if err := l.backend.AddTrackToCache(busName, trackFromSignalMetadata(meta), string(afterTrack)); err != nil {
+		logger.Error("[mpris] failed to add track for %s: %v", busName, err)
+	}
+}
+
+// handleTrackRemoved processes a track removal.
+// Body[0] = removed track ID
+func (l *Listener) handleTrackRemoved(busName string, sig *dbus.Signal) {
+	trackID, ok := arg[dbus.ObjectPath](sig, 0)
+	if !ok {
+		return
+	}
+
+	if err := l.backend.RemoveTrackFromCache(busName, string(trackID)); err != nil {
+		logger.Error("[mpris] failed to remove track for %s: %v", busName, err)
+	}
+}
+
+// handleTrackMetadataChanged processes per-track metadata updates.
+// Body[0] = track ID; Body[1] = new metadata
+func (l *Listener) handleTrackMetadataChanged(busName string, sig *dbus.Signal) {
+	trackID, ok := arg[dbus.ObjectPath](sig, 0)
+	if !ok {
+		return
+	}
+	meta, ok := arg[map[string]dbus.Variant](sig, 1)
+	if !ok {
+		return
+	}
+
+	if err := l.backend.UpdateTrackMetadataInCache(busName, string(trackID), trackFromSignalMetadata(meta)); err != nil {
+		logger.Error("[mpris] failed to update track metadata for %s: %v", busName, err)
 	}
 }
 

--- a/backend/mpris/mpris.go
+++ b/backend/mpris/mpris.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/godbus/dbus/v5"
 
-	"github.com/b0bbywan/go-odio-api/cache"
 	"github.com/b0bbywan/go-odio-api/config"
 	"github.com/b0bbywan/go-odio-api/events"
 	"github.com/b0bbywan/go-odio-api/logger"
@@ -29,9 +28,31 @@ func New(ctx context.Context, cfg *config.MPRISConfig) (*MPRISBackend, error) {
 		conn:    conn,
 		ctx:     ctx,
 		timeout: cfg.Timeout,
-		cache:   cache.New[[]Player](0), // TTL=0 = no expiration
 		events:  make(chan events.Event, 64),
 	}, nil
+}
+
+// updatePlayers hands fn a private copy of the cached players and stores fn's
+// result; fn may return nil to abort the write. playersMu serializes writers so
+// concurrent read-modify-writes can't drop each other; readers stay lock-free.
+// Returns false without calling fn when the cache was never loaded (nil) —
+// storing would wrongly mark the cache as valid.
+func (m *MPRISBackend) updatePlayers(fn func([]Player) []Player) bool {
+	m.playersMu.Lock()
+	defer m.playersMu.Unlock()
+
+	snapshot := m.players.Load()
+	if snapshot == nil {
+		return false
+	}
+
+	players := make([]Player, len(snapshot))
+	copy(players, snapshot)
+
+	if updated := fn(players); updated != nil {
+		m.players.Store(updated)
+	}
+	return true
 }
 
 // Start loads the initial cache and starts the listener
@@ -64,7 +85,7 @@ func (m *MPRISBackend) Start() error {
 // To force reload of a specific player, use ReloadPlayerFromDBus.
 func (m *MPRISBackend) ListPlayers() ([]Player, error) {
 	// Check cache first
-	if players, ok := m.cache.Get(CACHE_KEY); ok {
+	if players := m.players.Load(); players != nil {
 		logger.Debug("[mpris] returning %d players from cache", len(players))
 		return players, nil
 	}
@@ -96,7 +117,7 @@ func (m *MPRISBackend) ListPlayers() ([]Player, error) {
 	logger.Debug("[mpris] loaded %d players in %s", len(players), elapsed)
 
 	// Update cache
-	m.cache.Set(CACHE_KEY, players)
+	m.players.Store(players)
 
 	return players, nil
 }
@@ -109,8 +130,8 @@ func (m *MPRISBackend) GetPlayerFromCache(busName string) (*Player, error) {
 		return nil, err
 	}
 
-	players, ok := m.cache.Get(CACHE_KEY)
-	if !ok {
+	players := m.players.Load()
+	if players == nil {
 		return nil, &PlayerNotFoundError{BusName: busName}
 	}
 
@@ -126,30 +147,24 @@ func (m *MPRISBackend) GetPlayerFromCache(busName string) (*Player, error) {
 // If the player exists, it is replaced. Otherwise, it is added to the cache.
 // WARNING: If the cache is empty, this function reloads ALL players via ListPlayers.
 func (m *MPRISBackend) UpdatePlayer(updated Player) error {
-	players, ok := m.cache.Get(CACHE_KEY)
+	found := false
+	ok := m.updatePlayers(func(players []Player) []Player {
+		for i, player := range players {
+			if player.BusName == updated.BusName {
+				players[i] = updated
+				found = true
+				return players
+			}
+		}
+		// Player not in cache, add it
+		return append(players, updated)
+	})
 	if !ok {
 		// If no cache, reload everything
-		if _, err := m.ListPlayers(); err != nil {
-			return err
-		}
-		return nil
+		_, err := m.ListPlayers()
+		return err
 	}
 
-	found := false
-	for i, player := range players {
-		if player.BusName == updated.BusName {
-			players[i] = updated
-			found = true
-			break
-		}
-	}
-
-	if !found {
-		// Player not in cache, add it
-		players = append(players, updated)
-	}
-
-	m.cache.Set(CACHE_KEY, players)
 	eventType := events.TypePlayerUpdated
 	if !found {
 		eventType = events.TypePlayerAdded
@@ -187,15 +202,20 @@ func shouldAcceptPosition(p *Player, pos int64) bool {
 // Mainly used by the listener to update cache upon receiving
 // D-Bus PropertiesChanged signals. Does NOT make D-Bus calls.
 func (m *MPRISBackend) UpdatePlayerProperties(busName string, changed map[string]dbus.Variant) error {
-	players, ok := m.cache.Get(CACHE_KEY)
-	if !ok {
-		return &PlayerNotFoundError{BusName: busName}
-	}
-
-	for i, player := range players {
-		if player.BusName != busName {
-			continue
+	var updated Player
+	found := false
+	ok := m.updatePlayers(func(players []Player) []Player {
+		i := -1
+		for j := range players {
+			if players[j].BusName == busName {
+				i = j
+				break
+			}
 		}
+		if i < 0 {
+			return nil
+		}
+		found = true
 
 		// Update only properties that have changed
 		for key, variant := range changed {
@@ -267,13 +287,16 @@ func (m *MPRISBackend) UpdatePlayerProperties(busName string, changed map[string
 			}
 		}
 
-		m.cache.Set(CACHE_KEY, players)
-		m.notify(events.Event{Type: events.TypePlayerUpdated, Data: playerEnvelope(players[i])})
-		logger.Debug("[mpris] updated %d properties for player %s", len(changed), busName)
-		return nil
+		updated = players[i]
+		return players
+	})
+	if !ok || !found {
+		return &PlayerNotFoundError{BusName: busName}
 	}
 
-	return &PlayerNotFoundError{BusName: busName}
+	m.notify(events.Event{Type: events.TypePlayerUpdated, Data: playerEnvelope(updated)})
+	logger.Debug("[mpris] updated %d properties for player %s", len(changed), busName)
+	return nil
 }
 
 // UpdateProperty updates a single property of a player in the cache
@@ -286,26 +309,26 @@ func (m *MPRISBackend) UpdateProperty(busName, property string, value dbus.Varia
 // UpdatePositions updates positions for multiple players in a single cache pass
 // and emits a single player.position event with all updated positions.
 func (m *MPRISBackend) UpdatePositions(positions map[string]positionUpdate) {
-	players, ok := m.cache.Get(CACHE_KEY)
-	if !ok {
-		return
-	}
-
 	var updates []map[string]any
-	for i, player := range players {
-		if u, ok := positions[player.BusName]; ok {
-			players[i].Position = u.position
-			players[i].PositionUpdatedAt = time.UnixMilli(u.emittedAt)
-			updates = append(updates, map[string]any{
-				"bus_name":   player.BusName,
-				"track_id":   u.trackID,
-				"position":   u.position,
-				"emitted_at": u.emittedAt,
-			})
+	m.updatePlayers(func(players []Player) []Player {
+		for i, player := range players {
+			if u, ok := positions[player.BusName]; ok {
+				players[i].Position = u.position
+				players[i].PositionUpdatedAt = time.UnixMilli(u.emittedAt)
+				updates = append(updates, map[string]any{
+					"bus_name":   player.BusName,
+					"track_id":   u.trackID,
+					"position":   u.position,
+					"emitted_at": u.emittedAt,
+				})
+			}
 		}
-	}
+		if len(updates) == 0 {
+			return nil
+		}
+		return players
+	})
 
-	m.cache.Set(CACHE_KEY, players)
 	if len(updates) > 0 {
 		m.notify(events.Event{Type: events.TypePlayerPosition, Data: updates})
 	}
@@ -337,19 +360,19 @@ func (m *MPRISBackend) RemovePlayer(busName string) error {
 		return err
 	}
 
-	players, ok := m.cache.Get(CACHE_KEY)
+	ok := m.updatePlayers(func(players []Player) []Player {
+		filtered := make([]Player, 0, len(players))
+		for _, player := range players {
+			if player.BusName != busName {
+				filtered = append(filtered, player)
+			}
+		}
+		return filtered
+	})
 	if !ok {
 		return nil
 	}
 
-	filtered := make([]Player, 0, len(players))
-	for _, player := range players {
-		if player.BusName != busName {
-			filtered = append(filtered, player)
-		}
-	}
-
-	m.cache.Set(CACHE_KEY, filtered)
 	m.notify(events.Event{
 		Type: events.TypePlayerRemoved,
 		Data: map[string]string{"bus_name": busName},
@@ -363,10 +386,7 @@ func (m *MPRISBackend) RemovePlayer(busName string) error {
 // (e.g., "org.mpris.MediaPlayer2.spotify"). This function maps between the two
 // by searching in the cache. Returns "" if the player is not found.
 func (m *MPRISBackend) findPlayerByUniqueName(uniqueName string) string {
-	players, ok := m.cache.Get(CACHE_KEY)
-	if !ok {
-		return ""
-	}
+	players := m.players.Load()
 
 	for _, player := range players {
 		if player.uniqueName == uniqueName {
@@ -569,12 +589,12 @@ func (m *MPRISBackend) SetShuffle(busName string, shuffle bool) error {
 
 // CacheUpdatedAt returns the last time the player cache was written to.
 func (m *MPRISBackend) CacheUpdatedAt() time.Time {
-	return m.cache.UpdatedAt()
+	return m.players.UpdatedAt()
 }
 
 // InvalidateCache invalidates the entire cache
 func (m *MPRISBackend) InvalidateCache() {
-	m.cache.Delete(CACHE_KEY)
+	m.players.Reset()
 }
 
 // Close cleanly closes connections and stops the listener

--- a/backend/mpris/mpris.go
+++ b/backend/mpris/mpris.go
@@ -408,14 +408,23 @@ func (m *MPRISBackend) getPlayerFromDBus(busName string) (Player, error) {
 	return *player, nil
 }
 
-// Play starts playback
-func (m *MPRISBackend) Play(busName string) error {
+// requireCapability gates an action on a cached player's capability,
+// mapping a missing player or capability to the matching error.
+func (m *MPRISBackend) requireCapability(busName, required string, can func(*Player) bool) error {
 	player, err := m.GetPlayerFromCache(busName)
 	if err != nil {
 		return err
 	}
-	if !player.CanPlay() {
-		return &CapabilityError{Required: "CanPlay"}
+	if !can(player) {
+		return &CapabilityError{Required: required}
+	}
+	return nil
+}
+
+// Play starts playback
+func (m *MPRISBackend) Play(busName string) error {
+	if err := m.requireCapability(busName, "CanPlay", (*Player).CanPlay); err != nil {
+		return err
 	}
 
 	logger.Debug("[mpris] playing %s", busName)
@@ -424,12 +433,8 @@ func (m *MPRISBackend) Play(busName string) error {
 
 // Pause pauses playback
 func (m *MPRISBackend) Pause(busName string) error {
-	player, err := m.GetPlayerFromCache(busName)
-	if err != nil {
+	if err := m.requireCapability(busName, "CanPause", (*Player).CanPause); err != nil {
 		return err
-	}
-	if !player.CanPause() {
-		return &CapabilityError{Required: "CanPause"}
 	}
 
 	logger.Debug("[mpris] pausing %s", busName)
@@ -438,12 +443,9 @@ func (m *MPRISBackend) Pause(busName string) error {
 
 // PlayPause toggles between play and pause
 func (m *MPRISBackend) PlayPause(busName string) error {
-	player, err := m.GetPlayerFromCache(busName)
-	if err != nil {
+	canEither := func(p *Player) bool { return p.CanPlay() || p.CanPause() }
+	if err := m.requireCapability(busName, "CanPlay or CanPause", canEither); err != nil {
 		return err
-	}
-	if !player.CanPlay() && !player.CanPause() {
-		return &CapabilityError{Required: "CanPlay or CanPause"}
 	}
 
 	logger.Debug("[mpris] toggling play/pause for %s", busName)
@@ -452,12 +454,8 @@ func (m *MPRISBackend) PlayPause(busName string) error {
 
 // Stop stops playback
 func (m *MPRISBackend) Stop(busName string) error {
-	player, err := m.GetPlayerFromCache(busName)
-	if err != nil {
+	if err := m.requireCapability(busName, "CanControl", (*Player).CanControl); err != nil {
 		return err
-	}
-	if !player.CanControl() {
-		return &CapabilityError{Required: "CanControl"}
 	}
 
 	logger.Debug("[mpris] stopping %s", busName)
@@ -466,12 +464,8 @@ func (m *MPRISBackend) Stop(busName string) error {
 
 // Next skips to the next track
 func (m *MPRISBackend) Next(busName string) error {
-	player, err := m.GetPlayerFromCache(busName)
-	if err != nil {
+	if err := m.requireCapability(busName, "CanGoNext", (*Player).CanGoNext); err != nil {
 		return err
-	}
-	if !player.CanGoNext() {
-		return &CapabilityError{Required: "CanGoNext"}
 	}
 
 	logger.Debug("[mpris] next track for %s", busName)
@@ -480,12 +474,8 @@ func (m *MPRISBackend) Next(busName string) error {
 
 // Previous goes back to the previous track
 func (m *MPRISBackend) Previous(busName string) error {
-	player, err := m.GetPlayerFromCache(busName)
-	if err != nil {
+	if err := m.requireCapability(busName, "CanGoPrevious", (*Player).CanGoPrevious); err != nil {
 		return err
-	}
-	if !player.CanGoPrevious() {
-		return &CapabilityError{Required: "CanGoPrevious"}
 	}
 
 	logger.Debug("[mpris] previous track for %s", busName)
@@ -494,12 +484,8 @@ func (m *MPRISBackend) Previous(busName string) error {
 
 // Seek moves the playback position
 func (m *MPRISBackend) Seek(busName string, offset int64) error {
-	player, err := m.GetPlayerFromCache(busName)
-	if err != nil {
+	if err := m.requireCapability(busName, "CanSeek", (*Player).CanSeek); err != nil {
 		return err
-	}
-	if !player.CanSeek() {
-		return &CapabilityError{Required: "CanSeek"}
 	}
 
 	logger.Debug("[mpris] seeking %d for %s", offset, busName)
@@ -540,12 +526,8 @@ func (m *MPRISBackend) SetVolume(busName string, volume float64) error {
 		return &ValidationError{Field: "volume", Message: "must be between 0 and 1"}
 	}
 
-	player, err := m.GetPlayerFromCache(busName)
-	if err != nil {
+	if err := m.requireCapability(busName, "CanControl", (*Player).CanControl); err != nil {
 		return err
-	}
-	if !player.CanControl() {
-		return &CapabilityError{Required: "CanControl"}
 	}
 
 	logger.Debug("[mpris] setting volume to %.2f for %s", volume, busName)
@@ -561,12 +543,8 @@ func (m *MPRISBackend) SetLoopStatus(busName string, status LoopStatus) error {
 		return &ValidationError{Field: "loop", Message: "must be None, Track, or Playlist"}
 	}
 
-	player, err := m.GetPlayerFromCache(busName)
-	if err != nil {
+	if err := m.requireCapability(busName, "CanControl", (*Player).CanControl); err != nil {
 		return err
-	}
-	if !player.CanControl() {
-		return &CapabilityError{Required: "CanControl"}
 	}
 
 	logger.Debug("[mpris] setting loop status to %s for %s", status, busName)
@@ -575,12 +553,8 @@ func (m *MPRISBackend) SetLoopStatus(busName string, status LoopStatus) error {
 
 // SetShuffle enables/disables shuffle mode
 func (m *MPRISBackend) SetShuffle(busName string, shuffle bool) error {
-	player, err := m.GetPlayerFromCache(busName)
-	if err != nil {
+	if err := m.requireCapability(busName, "CanControl", (*Player).CanControl); err != nil {
 		return err
-	}
-	if !player.CanControl() {
-		return &CapabilityError{Required: "CanControl"}
 	}
 
 	logger.Debug("[mpris] setting shuffle to %v for %s", shuffle, busName)

--- a/backend/mpris/mpris.go
+++ b/backend/mpris/mpris.go
@@ -260,30 +260,8 @@ func (m *MPRISBackend) UpdatePlayerProperties(busName string, changed map[string
 					players[i].Position = val
 					players[i].PositionUpdatedAt = time.Now()
 				}
-			case "CanPlay":
-				if val, ok := extract[bool](variant); ok {
-					players[i].Capabilities.CanPlay = val
-				}
-			case "CanPause":
-				if val, ok := extract[bool](variant); ok {
-					players[i].Capabilities.CanPause = val
-				}
-			case "CanGoNext":
-				if val, ok := extract[bool](variant); ok {
-					players[i].Capabilities.CanGoNext = val
-				}
-			case "CanGoPrevious":
-				if val, ok := extract[bool](variant); ok {
-					players[i].Capabilities.CanGoPrevious = val
-				}
-			case "CanSeek":
-				if val, ok := extract[bool](variant); ok {
-					players[i].Capabilities.CanSeek = val
-				}
-			case "CanControl":
-				if val, ok := extract[bool](variant); ok {
-					players[i].Capabilities.CanControl = val
-				}
+			case "CanPlay", "CanPause", "CanGoNext", "CanGoPrevious", "CanSeek", "CanControl":
+				players[i].Capabilities.setFromProp(key, variant)
 			}
 		}
 

--- a/backend/mpris/mpris.go
+++ b/backend/mpris/mpris.go
@@ -221,23 +221,23 @@ func (m *MPRISBackend) UpdatePlayerProperties(busName string, changed map[string
 		for key, variant := range changed {
 			switch key {
 			case "PlaybackStatus":
-				if val, ok := extractString(variant); ok {
+				if val, ok := extract[string](variant); ok {
 					players[i].PlaybackStatus = PlaybackStatus(val)
 				}
 			case "LoopStatus":
-				if val, ok := extractString(variant); ok {
+				if val, ok := extract[string](variant); ok {
 					players[i].LoopStatus = LoopStatus(val)
 				}
 			case "Shuffle":
-				if val, ok := extractBool(variant); ok {
+				if val, ok := extract[bool](variant); ok {
 					players[i].Shuffle = val
 				}
 			case "Volume":
-				if val, ok := extractFloat64(variant); ok {
+				if val, ok := extract[float64](variant); ok {
 					players[i].Volume = &val
 				}
 			case "Metadata":
-				if metaMap, ok := extractMetadataMap(variant); ok {
+				if metaMap, ok := extract[map[string]dbus.Variant](variant); ok {
 					oldTrackID := players[i].Metadata["mpris:trackid"]
 					players[i].Metadata = make(map[string]string)
 					for k, v := range metaMap {
@@ -252,36 +252,36 @@ func (m *MPRISBackend) UpdatePlayerProperties(busName string, changed map[string
 					}
 				}
 			case "Rate":
-				if val, ok := extractFloat64(variant); ok {
+				if val, ok := extract[float64](variant); ok {
 					players[i].Rate = val
 				}
 			case "Position":
-				if val, ok := extractInt64(variant); ok && shouldAcceptPosition(&players[i], val) {
+				if val, ok := extract[int64](variant); ok && shouldAcceptPosition(&players[i], val) {
 					players[i].Position = val
 					players[i].PositionUpdatedAt = time.Now()
 				}
 			case "CanPlay":
-				if val, ok := extractBool(variant); ok {
+				if val, ok := extract[bool](variant); ok {
 					players[i].Capabilities.CanPlay = val
 				}
 			case "CanPause":
-				if val, ok := extractBool(variant); ok {
+				if val, ok := extract[bool](variant); ok {
 					players[i].Capabilities.CanPause = val
 				}
 			case "CanGoNext":
-				if val, ok := extractBool(variant); ok {
+				if val, ok := extract[bool](variant); ok {
 					players[i].Capabilities.CanGoNext = val
 				}
 			case "CanGoPrevious":
-				if val, ok := extractBool(variant); ok {
+				if val, ok := extract[bool](variant); ok {
 					players[i].Capabilities.CanGoPrevious = val
 				}
 			case "CanSeek":
-				if val, ok := extractBool(variant); ok {
+				if val, ok := extract[bool](variant); ok {
 					players[i].Capabilities.CanSeek = val
 				}
 			case "CanControl":
-				if val, ok := extractBool(variant); ok {
+				if val, ok := extract[bool](variant); ok {
 					players[i].Capabilities.CanControl = val
 				}
 			}

--- a/backend/mpris/mpris_test.go
+++ b/backend/mpris/mpris_test.go
@@ -965,14 +965,15 @@ func TestPlayerStructTags(t *testing.T) {
 		dbusTag  string
 		ifaceTag string
 	}{
-		"Identity":       {dbusTag: "Identity", ifaceTag: "org.mpris.MediaPlayer2"},
-		"PlaybackStatus": {dbusTag: "PlaybackStatus", ifaceTag: "org.mpris.MediaPlayer2.Player"},
-		"LoopStatus":     {dbusTag: "LoopStatus", ifaceTag: "org.mpris.MediaPlayer2.Player"},
-		"Shuffle":        {dbusTag: "Shuffle", ifaceTag: "org.mpris.MediaPlayer2.Player"},
-		"Volume":         {dbusTag: "Volume", ifaceTag: "org.mpris.MediaPlayer2.Player"},
-		"Position":       {dbusTag: "Position", ifaceTag: "org.mpris.MediaPlayer2.Player"},
-		"Rate":           {dbusTag: "Rate", ifaceTag: "org.mpris.MediaPlayer2.Player"},
-		"Metadata":       {dbusTag: "Metadata", ifaceTag: "org.mpris.MediaPlayer2.Player"},
+		"Identity":            {dbusTag: "Identity", ifaceTag: "org.mpris.MediaPlayer2"},
+		"SupportedUriSchemes": {dbusTag: "SupportedUriSchemes", ifaceTag: "org.mpris.MediaPlayer2"},
+		"PlaybackStatus":      {dbusTag: "PlaybackStatus", ifaceTag: "org.mpris.MediaPlayer2.Player"},
+		"LoopStatus":          {dbusTag: "LoopStatus", ifaceTag: "org.mpris.MediaPlayer2.Player"},
+		"Shuffle":             {dbusTag: "Shuffle", ifaceTag: "org.mpris.MediaPlayer2.Player"},
+		"Volume":              {dbusTag: "Volume", ifaceTag: "org.mpris.MediaPlayer2.Player"},
+		"Position":            {dbusTag: "Position", ifaceTag: "org.mpris.MediaPlayer2.Player"},
+		"Rate":                {dbusTag: "Rate", ifaceTag: "org.mpris.MediaPlayer2.Player"},
+		"Metadata":            {dbusTag: "Metadata", ifaceTag: "org.mpris.MediaPlayer2.Player"},
 	}
 
 	for i := 0; i < playerType.NumField(); i++ {

--- a/backend/mpris/mpris_test.go
+++ b/backend/mpris/mpris_test.go
@@ -1,18 +1,79 @@
 package mpris
 
 import (
+	"fmt"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 
-	"github.com/b0bbywan/go-odio-api/cache"
 	"github.com/godbus/dbus/v5"
+
+	"github.com/b0bbywan/go-odio-api/events"
 )
 
-func TestGetPlayerFromCache(t *testing.T) {
-	backend := &MPRISBackend{
-		cache: cache.New[[]Player](0),
+// Readers must hold immutable snapshots: a writer updating the cache while a
+// reader walks a player's metadata must not race (-race enforces this).
+func TestConcurrentReadersWriters(t *testing.T) {
+	const busName = "org.mpris.MediaPlayer2.test"
+
+	b := &MPRISBackend{events: make(chan events.Event, 16)}
+	drained := make(chan struct{})
+	go func() {
+		defer close(drained)
+		for range b.events {
+		}
+	}()
+
+	b.players.Store([]Player{{
+		BusName:  busName,
+		Metadata: map[string]string{"mpris:trackid": "/track/0"},
+	}})
+
+	var wg sync.WaitGroup
+	for w := 0; w < 2; w++ {
+		wg.Add(1)
+		go func(seed int) {
+			defer wg.Done()
+			for i := 0; i < 300; i++ {
+				changed := map[string]dbus.Variant{
+					"Metadata": dbus.MakeVariant(map[string]dbus.Variant{
+						"mpris:trackid": dbus.MakeVariant(dbus.ObjectPath(fmt.Sprintf("/track/%d-%d", seed, i))),
+						"xesam:title":   dbus.MakeVariant("Song"),
+					}),
+				}
+				if err := b.UpdatePlayerProperties(busName, changed); err != nil {
+					t.Errorf("UpdatePlayerProperties: %v", err)
+					return
+				}
+			}
+		}(w)
 	}
+	for r := 0; r < 2; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 300; i++ {
+				players, err := b.ListPlayers()
+				if err != nil {
+					t.Errorf("ListPlayers: %v", err)
+					return
+				}
+				for _, p := range players {
+					for k, v := range p.Metadata {
+						_, _ = k, v
+					}
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	close(b.events)
+	<-drained
+}
+
+func TestGetPlayerFromCache(t *testing.T) {
+	backend := &MPRISBackend{}
 
 	// Populate cache with test players
 	players := []Player{
@@ -39,7 +100,7 @@ func TestGetPlayerFromCache(t *testing.T) {
 			},
 		},
 	}
-	backend.cache.Set(CACHE_KEY, players)
+	backend.players.Store(players)
 
 	tests := []struct {
 		name       string
@@ -115,9 +176,7 @@ func TestGetPlayerFromCache(t *testing.T) {
 }
 
 func TestGetPlayerFromCacheEmptyCache(t *testing.T) {
-	backend := &MPRISBackend{
-		cache: cache.New[[]Player](0),
-	}
+	backend := &MPRISBackend{}
 
 	player, err := backend.GetPlayerFromCache("org.mpris.MediaPlayer2.test")
 	if err == nil {
@@ -129,9 +188,7 @@ func TestGetPlayerFromCacheEmptyCache(t *testing.T) {
 }
 
 func TestUpdatePlayer(t *testing.T) {
-	backend := &MPRISBackend{
-		cache: cache.New[[]Player](0),
-	}
+	backend := &MPRISBackend{}
 
 	// Initial cache state
 	half, full, eightyPct := 0.5, 1.0, 0.8
@@ -149,7 +206,7 @@ func TestUpdatePlayer(t *testing.T) {
 			Volume:         &full,
 		},
 	}
-	backend.cache.Set(CACHE_KEY, initialPlayers)
+	backend.players.Store(initialPlayers)
 
 	// Update an existing player
 	updatedPlayer := Player{
@@ -191,9 +248,7 @@ func TestUpdatePlayer(t *testing.T) {
 }
 
 func TestUpdatePlayerAddNew(t *testing.T) {
-	backend := &MPRISBackend{
-		cache: cache.New[[]Player](0),
-	}
+	backend := &MPRISBackend{}
 
 	// Initial cache with one player
 	initialPlayers := []Player{
@@ -202,7 +257,7 @@ func TestUpdatePlayerAddNew(t *testing.T) {
 			Identity: "Spotify",
 		},
 	}
-	backend.cache.Set(CACHE_KEY, initialPlayers)
+	backend.players.Store(initialPlayers)
 
 	// Add a new player
 	newPlayer := Player{
@@ -229,16 +284,14 @@ func TestUpdatePlayerAddNew(t *testing.T) {
 	}
 
 	// Verify we now have 2 players in cache
-	players, _ := backend.cache.Get(CACHE_KEY)
+	players := backend.players.Load()
 	if len(players) != 2 {
 		t.Errorf("Cache should contain 2 players, got %d", len(players))
 	}
 }
 
 func TestRemovePlayer(t *testing.T) {
-	backend := &MPRISBackend{
-		cache: cache.New[[]Player](0),
-	}
+	backend := &MPRISBackend{}
 
 	// Populate cache with two players
 	players := []Player{
@@ -251,7 +304,7 @@ func TestRemovePlayer(t *testing.T) {
 			Identity: "VLC",
 		},
 	}
-	backend.cache.Set(CACHE_KEY, players)
+	backend.players.Store(players)
 
 	// Remove one player
 	err := backend.RemovePlayer("org.mpris.MediaPlayer2.spotify")
@@ -275,22 +328,20 @@ func TestRemovePlayer(t *testing.T) {
 	}
 
 	// Verify cache size
-	cachedPlayers, _ := backend.cache.Get(CACHE_KEY)
+	cachedPlayers := backend.players.Load()
 	if len(cachedPlayers) != 1 {
 		t.Errorf("Cache should contain 1 player, got %d", len(cachedPlayers))
 	}
 }
 
 func TestInvalidateCache(t *testing.T) {
-	backend := &MPRISBackend{
-		cache: cache.New[[]Player](0),
-	}
+	backend := &MPRISBackend{}
 
 	// Populate cache
 	players := []Player{
 		{BusName: "org.mpris.MediaPlayer2.test", Identity: "Test"},
 	}
-	backend.cache.Set(CACHE_KEY, players)
+	backend.players.Store(players)
 
 	// Verify cache is populated
 	_, err := backend.GetPlayerFromCache("org.mpris.MediaPlayer2.test")
@@ -1241,8 +1292,8 @@ func TestUpdatePlayerPropertiesPosition(t *testing.T) {
 	const busName = "org.mpris.MediaPlayer2.test"
 
 	newBackend := func(initial Player) *MPRISBackend {
-		b := &MPRISBackend{cache: cache.New[[]Player](0)}
-		b.cache.Set(CACHE_KEY, []Player{initial})
+		b := &MPRISBackend{}
+		b.players.Store([]Player{initial})
 		return b
 	}
 
@@ -1350,8 +1401,8 @@ func TestUpdatePlayerPropertiesCapabilities(t *testing.T) {
 	const busName = "org.mpris.MediaPlayer2.test"
 
 	newBackend := func(initial Player) *MPRISBackend {
-		b := &MPRISBackend{cache: cache.New[[]Player](0)}
-		b.cache.Set(CACHE_KEY, []Player{initial})
+		b := &MPRISBackend{}
+		b.players.Store([]Player{initial})
 		return b
 	}
 

--- a/backend/mpris/mpris_test.go
+++ b/backend/mpris/mpris_test.go
@@ -549,12 +549,12 @@ func TestExtractString(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			value, ok := extractString(tt.variant)
+			value, ok := extract[string](tt.variant)
 			if ok != tt.wantOk {
-				t.Errorf("extractString() ok = %v, want %v", ok, tt.wantOk)
+				t.Errorf("extract[string]() ok = %v, want %v", ok, tt.wantOk)
 			}
 			if value != tt.wantValue {
-				t.Errorf("extractString() value = %q, want %q", value, tt.wantValue)
+				t.Errorf("extract[string]() value = %q, want %q", value, tt.wantValue)
 			}
 		})
 	}
@@ -589,12 +589,12 @@ func TestExtractBool(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			value, ok := extractBool(tt.variant)
+			value, ok := extract[bool](tt.variant)
 			if ok != tt.wantOk {
-				t.Errorf("extractBool() ok = %v, want %v", ok, tt.wantOk)
+				t.Errorf("extract[bool]() ok = %v, want %v", ok, tt.wantOk)
 			}
 			if value != tt.wantValue {
-				t.Errorf("extractBool() value = %v, want %v", value, tt.wantValue)
+				t.Errorf("extract[bool]() value = %v, want %v", value, tt.wantValue)
 			}
 		})
 	}
@@ -635,12 +635,12 @@ func TestExtractInt64(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			value, ok := extractInt64(tt.variant)
+			value, ok := extract[int64](tt.variant)
 			if ok != tt.wantOk {
-				t.Errorf("extractInt64() ok = %v, want %v", ok, tt.wantOk)
+				t.Errorf("extract[int64]() ok = %v, want %v", ok, tt.wantOk)
 			}
 			if value != tt.wantValue {
-				t.Errorf("extractInt64() value = %v, want %v", value, tt.wantValue)
+				t.Errorf("extract[int64]() value = %v, want %v", value, tt.wantValue)
 			}
 		})
 	}
@@ -681,12 +681,12 @@ func TestExtractFloat64(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			value, ok := extractFloat64(tt.variant)
+			value, ok := extract[float64](tt.variant)
 			if ok != tt.wantOk {
-				t.Errorf("extractFloat64() ok = %v, want %v", ok, tt.wantOk)
+				t.Errorf("extract[float64]() ok = %v, want %v", ok, tt.wantOk)
 			}
 			if value != tt.wantValue {
-				t.Errorf("extractFloat64() value = %v, want %v", value, tt.wantValue)
+				t.Errorf("extract[float64]() value = %v, want %v", value, tt.wantValue)
 			}
 		})
 	}
@@ -719,9 +719,9 @@ func TestExtractMetadataMap(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, ok := extractMetadataMap(tt.variant)
+			_, ok := extract[map[string]dbus.Variant](tt.variant)
 			if ok != tt.wantOk {
-				t.Errorf("extractMetadataMap() ok = %v, want %v", ok, tt.wantOk)
+				t.Errorf("extract[map[string]dbus.Variant]() ok = %v, want %v", ok, tt.wantOk)
 			}
 		})
 	}

--- a/backend/mpris/player.go
+++ b/backend/mpris/player.go
@@ -140,6 +140,13 @@ func (p *Player) loadFromDBus() error {
 				field.SetInt(val)
 			}
 
+		case reflect.Slice:
+			if field.Type().Elem().Kind() == reflect.String {
+				if val, ok := extractStringSlice(variant); ok {
+					field.Set(reflect.ValueOf(val))
+				}
+			}
+
 		case reflect.Map:
 			// Special case for Metadata
 			if dbusTag == "Metadata" {

--- a/backend/mpris/player.go
+++ b/backend/mpris/player.go
@@ -233,34 +233,30 @@ func trackFromSignalMetadata(meta map[string]dbus.Variant) Track {
 	return track
 }
 
-// loadCapabilitiesFromProps loads capabilities from already retrieved properties.
-// Used by loadFromDBus() to avoid additional D-Bus calls.
-// Maps D-Bus properties (CanPlay, CanPause, etc.) to the Capabilities struct
-// using reflection and `dbus` tags.
-func (p *Player) loadCapabilitiesFromProps(props map[string]dbus.Variant) Capabilities {
-	var caps Capabilities
-
-	val := reflect.ValueOf(&caps).Elem()
-	typ := val.Type()
-
-	for i := 0; i < val.NumField(); i++ {
-		field := val.Field(i)
-		fieldType := typ.Field(i)
-
-		// Retrieve dbus tag
-		dbusTag := fieldType.Tag.Get("dbus")
-		if dbusTag == "" {
-			continue
-		}
-
-		// Retrieve property from props
-		if variant, ok := props[dbusTag]; ok {
-			if boolVal, ok := extract[bool](variant); ok {
-				field.SetBool(boolVal)
-			}
+// setFromProp sets the Capabilities field whose `dbus` tag matches name;
+// no-op when no field matches or the variant does not hold a bool.
+func (c *Capabilities) setFromProp(name string, variant dbus.Variant) {
+	val, ok := extract[bool](variant)
+	if !ok {
+		return
+	}
+	v := reflect.ValueOf(c).Elem()
+	typ := v.Type()
+	for i := 0; i < v.NumField(); i++ {
+		if typ.Field(i).Tag.Get("dbus") == name {
+			v.Field(i).SetBool(val)
+			return
 		}
 	}
+}
 
+// loadCapabilitiesFromProps loads capabilities from already retrieved
+// properties, avoiding additional D-Bus calls.
+func (p *Player) loadCapabilitiesFromProps(props map[string]dbus.Variant) Capabilities {
+	var caps Capabilities
+	for name, variant := range props {
+		caps.setFromProp(name, variant)
+	}
 	return caps
 }
 

--- a/backend/mpris/player.go
+++ b/backend/mpris/player.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	"github.com/godbus/dbus/v5"
+
+	"github.com/b0bbywan/go-odio-api/logger"
 )
 
 // newPlayer creates a new Player with backend connection
@@ -149,9 +151,79 @@ func (p *Player) loadFromDBus() error {
 	// Load capabilities from already retrieved properties
 	p.Capabilities = p.loadCapabilitiesFromProps(propsPlayer)
 
+	p.loadTracklist()
+
 	p.PositionUpdatedAt = time.Now()
 
 	return nil
+}
+
+// loadTracklist probes the optional TrackList interface. Never fails:
+// any error just leaves the player marked as not supporting tracklists.
+func (p *Player) loadTracklist() {
+	props, err := p.getAllProperties(MPRIS_TRACKLIST_IFACE)
+	if err != nil {
+		logger.Debug("[mpris] no tracklist for %s: %v", p.BusName, err)
+		return
+	}
+
+	tracksVariant, ok := props["Tracks"]
+	if !ok {
+		return
+	}
+	p.TracklistSupported = true
+
+	if v, ok := props["CanEditTracks"]; ok {
+		if canEdit, ok := extractBool(v); ok {
+			p.CanEditTracks = canEdit
+		}
+	}
+
+	ids, ok := tracksVariant.Value().([]dbus.ObjectPath)
+	if !ok || len(ids) == 0 {
+		return
+	}
+
+	metas, err := p.getTracksMetadata(ids)
+	if err != nil {
+		logger.Debug("[mpris] GetTracksMetadata failed for %s, falling back to IDs only: %v", p.BusName, err)
+		p.Tracklist = tracksFromIDs(ids)
+		return
+	}
+	p.Tracklist = tracksFromMetadata(ids, metas)
+}
+
+// tracksFromMetadata zips ordered track IDs with their metadata.
+// TrackID always comes from ids so players omitting mpris:trackid still work.
+func tracksFromMetadata(ids []dbus.ObjectPath, metas []map[string]dbus.Variant) []Track {
+	tracks := make([]Track, len(ids))
+	for i, id := range ids {
+		tracks[i] = Track{TrackID: string(id)}
+		if i < len(metas) {
+			tracks[i].Metadata = extractMetadata(metas[i])
+		}
+	}
+	return tracks
+}
+
+func tracksFromIDs(ids []dbus.ObjectPath) []Track {
+	tracks := make([]Track, len(ids))
+	for i, id := range ids {
+		tracks[i] = Track{TrackID: string(id)}
+	}
+	return tracks
+}
+
+// trackFromSignalMetadata builds a Track from signal-provided metadata,
+// where the ID can only come from mpris:trackid.
+func trackFromSignalMetadata(meta map[string]dbus.Variant) Track {
+	track := Track{Metadata: extractMetadata(meta)}
+	if v, ok := meta["mpris:trackid"]; ok {
+		if id, ok := v.Value().(dbus.ObjectPath); ok {
+			track.TrackID = string(id)
+		}
+	}
+	return track
 }
 
 // loadCapabilitiesFromProps loads capabilities from already retrieved properties.

--- a/backend/mpris/player.go
+++ b/backend/mpris/player.go
@@ -112,17 +112,17 @@ func (p *Player) loadFromDBus() error {
 		// Handle according to field type
 		switch field.Kind() {
 		case reflect.String:
-			if val, ok := extractString(variant); ok {
+			if val, ok := extract[string](variant); ok {
 				field.SetString(val)
 			}
 
 		case reflect.Bool:
-			if val, ok := extractBool(variant); ok {
+			if val, ok := extract[bool](variant); ok {
 				field.SetBool(val)
 			}
 
 		case reflect.Float64:
-			if val, ok := extractFloat64(variant); ok {
+			if val, ok := extract[float64](variant); ok {
 				field.SetFloat(val)
 			}
 
@@ -130,19 +130,19 @@ func (p *Player) loadFromDBus() error {
 			// Volume is *float64 so we can distinguish "muted to 0" from
 			// "player does not expose the property" (nil → JSON-omitted).
 			if field.Type().Elem().Kind() == reflect.Float64 {
-				if val, ok := extractFloat64(variant); ok {
+				if val, ok := extract[float64](variant); ok {
 					field.Set(reflect.ValueOf(&val))
 				}
 			}
 
 		case reflect.Int64:
-			if val, ok := extractInt64(variant); ok {
+			if val, ok := extract[int64](variant); ok {
 				field.SetInt(val)
 			}
 
 		case reflect.Slice:
 			if field.Type().Elem().Kind() == reflect.String {
-				if val, ok := extractStringSlice(variant); ok {
+				if val, ok := extract[[]string](variant); ok {
 					field.Set(reflect.ValueOf(val))
 				}
 			}
@@ -181,7 +181,7 @@ func (p *Player) loadTracklist() {
 	p.TracklistSupported = true
 
 	if v, ok := props["CanEditTracks"]; ok {
-		if canEdit, ok := extractBool(v); ok {
+		if canEdit, ok := extract[bool](v); ok {
 			p.CanEditTracks = canEdit
 		}
 	}
@@ -255,7 +255,7 @@ func (p *Player) loadCapabilitiesFromProps(props map[string]dbus.Variant) Capabi
 
 		// Retrieve property from props
 		if variant, ok := props[dbusTag]; ok {
-			if boolVal, ok := extractBool(variant); ok {
+			if boolVal, ok := extract[bool](variant); ok {
 				field.SetBool(boolVal)
 			}
 		}

--- a/backend/mpris/tracklist.go
+++ b/backend/mpris/tracklist.go
@@ -1,6 +1,9 @@
 package mpris
 
 import (
+	"net/url"
+	"path"
+	"slices"
 	"time"
 
 	"github.com/godbus/dbus/v5"
@@ -8,6 +11,19 @@ import (
 	"github.com/b0bbywan/go-odio-api/events"
 	"github.com/b0bbywan/go-odio-api/logger"
 )
+
+// resolveTrackRef resolves an API-supplied track reference — a full object
+// path or just its last segment — against the cached tracklist. Track IDs are
+// player-chosen object paths with no common prefix, so the cache is the only
+// way to rebuild the full path from a bare ID.
+func resolveTrackRef(tracks []Track, ref string) (string, bool) {
+	for i := range tracks {
+		if tracks[i].TrackID == ref || path.Base(tracks[i].TrackID) == ref {
+			return tracks[i].TrackID, true
+		}
+	}
+	return "", false
+}
 
 // mutateTracklist applies fn to the cached player and broadcasts the resulting
 // tracklist snapshot. fn returns false for no-op mutations (nothing stored,
@@ -206,14 +222,16 @@ func (m *MPRISBackend) GetTracklist(busName string) (*TracklistResponse, error) 
 	return &TracklistResponse{CanEditTracks: player.CanEditTracks, Tracks: tracks}, nil
 }
 
-// GoTo skips to the given track. Not gated on CanEditTracks: the spec doesn't
-// class GoTo as an edit operation.
-func (m *MPRISBackend) GoTo(busName, trackID string) error {
-	if _, err := m.tracklistPlayer(busName); err != nil {
+// GoTo skips to the referenced track. Not gated on CanEditTracks: the spec
+// doesn't class GoTo as an edit operation.
+func (m *MPRISBackend) GoTo(busName, trackRef string) error {
+	player, err := m.tracklistPlayer(busName)
+	if err != nil {
 		return err
 	}
-	if !dbus.ObjectPath(trackID).IsValid() {
-		return &ValidationError{Field: "track_id", Message: "must be a valid D-Bus object path"}
+	trackID, ok := resolveTrackRef(player.Tracklist, trackRef)
+	if !ok {
+		return &ValidationError{Field: "track_id", Message: "unknown track: " + trackRef}
 	}
 
 	logger.Debug("[mpris] going to track %s for %s", trackID, busName)
@@ -227,32 +245,46 @@ func (m *MPRISBackend) AddTrack(busName, uri, afterTrack string, setAsCurrent bo
 	if err != nil {
 		return err
 	}
-	if uri == "" {
-		return &ValidationError{Field: "uri", Message: "must not be empty"}
+	// The spec requires an absolute URI whose scheme the player declared in
+	// SupportedUriSchemes; a bare path would be silently dropped player-side.
+	u, err := url.Parse(uri)
+	if err != nil || u.Scheme == "" {
+		return &ValidationError{Field: "uri", Message: "must be an absolute URI (e.g. file:///path or http://...)"}
+	}
+	if len(player.SupportedUriSchemes) > 0 && !slices.Contains(player.SupportedUriSchemes, u.Scheme) {
+		return &ValidationError{Field: "uri", Message: "scheme " + u.Scheme + " not supported by player"}
 	}
 
-	if afterTrack == "" {
+	switch afterTrack {
+	case "":
 		if n := len(player.Tracklist); n > 0 {
 			afterTrack = player.Tracklist[n-1].TrackID
 		} else {
 			afterTrack = MPRIS_NO_TRACK
 		}
-	}
-	if !dbus.ObjectPath(afterTrack).IsValid() {
-		return &ValidationError{Field: "after_track", Message: "must be a valid D-Bus object path"}
+	case MPRIS_NO_TRACK, "NoTrack": // explicit prepend
+		afterTrack = MPRIS_NO_TRACK
+	default:
+		resolved, ok := resolveTrackRef(player.Tracklist, afterTrack)
+		if !ok {
+			return &ValidationError{Field: "after_track", Message: "unknown track: " + afterTrack}
+		}
+		afterTrack = resolved
 	}
 
 	logger.Debug("[mpris] adding track %s after %s for %s", uri, afterTrack, busName)
 	return m.callMethod(busName, MPRIS_METHOD_ADD_TRACK, uri, dbus.ObjectPath(afterTrack), setAsCurrent)
 }
 
-// RemoveTrack asks the player to remove a track from its tracklist.
-func (m *MPRISBackend) RemoveTrack(busName, trackID string) error {
-	if _, err := m.editableTracklistPlayer(busName); err != nil {
+// RemoveTrack asks the player to remove the referenced track from its tracklist.
+func (m *MPRISBackend) RemoveTrack(busName, trackRef string) error {
+	player, err := m.editableTracklistPlayer(busName)
+	if err != nil {
 		return err
 	}
-	if !dbus.ObjectPath(trackID).IsValid() {
-		return &ValidationError{Field: "track_id", Message: "must be a valid D-Bus object path"}
+	trackID, ok := resolveTrackRef(player.Tracklist, trackRef)
+	if !ok {
+		return &ValidationError{Field: "track_id", Message: "unknown track: " + trackRef}
 	}
 
 	logger.Debug("[mpris] removing track %s for %s", trackID, busName)

--- a/backend/mpris/tracklist.go
+++ b/backend/mpris/tracklist.go
@@ -1,0 +1,245 @@
+package mpris
+
+import (
+	"time"
+
+	"github.com/godbus/dbus/v5"
+
+	"github.com/b0bbywan/go-odio-api/events"
+	"github.com/b0bbywan/go-odio-api/logger"
+)
+
+// mutateTracklist applies fn to the cached player and broadcasts the resulting
+// tracklist snapshot. fn returns false for no-op mutations (nothing stored,
+// nothing broadcast). fn must respect updatePlayers' copy-on-write contract:
+// replace the Tracklist slice, never mutate it in place.
+func (m *MPRISBackend) mutateTracklist(busName string, fn func(p *Player) bool) error {
+	var snapshot Player
+	found, changed := false, false
+	ok := m.updatePlayers(func(players []Player) []Player {
+		for i := range players {
+			if players[i].BusName != busName {
+				continue
+			}
+			found = true
+			if !fn(&players[i]) {
+				return nil
+			}
+			changed = true
+			snapshot = players[i]
+			return players
+		}
+		return nil
+	})
+	if !ok || !found {
+		return &PlayerNotFoundError{BusName: busName}
+	}
+
+	if changed {
+		m.notify(events.Event{Type: events.TypePlayerTracklist, Data: tracklistEnvelope(snapshot)})
+	}
+	return nil
+}
+
+func tracklistEnvelope(p Player) map[string]any {
+	tracks := p.Tracklist
+	if tracks == nil {
+		tracks = []Track{}
+	}
+	return map[string]any{
+		"bus_name":        p.BusName,
+		"can_edit_tracks": p.CanEditTracks,
+		"tracks":          tracks,
+		"emitted_at":      time.Now().UnixMilli(),
+	}
+}
+
+// ReplaceTracklist wholesale-replaces a player's tracklist (TrackListReplaced).
+func (m *MPRISBackend) ReplaceTracklist(busName string, tracks []Track) error {
+	return m.mutateTracklist(busName, func(p *Player) bool {
+		p.TracklistSupported = true
+		p.Tracklist = tracks
+		return true
+	})
+}
+
+// AddTrackToCache inserts a track after afterTrack (TrackAdded signal).
+func (m *MPRISBackend) AddTrackToCache(busName string, track Track, afterTrack string) error {
+	return m.mutateTracklist(busName, func(p *Player) bool {
+		// A player emitting TrackList signals supports the interface even if
+		// the initial GetAll failed (lazy init).
+		p.TracklistSupported = true
+		p.Tracklist = insertTrack(p.Tracklist, track, afterTrack)
+		return true
+	})
+}
+
+// insertTrack returns a new slice with track inserted after afterTrack:
+// the NoTrack sentinel prepends, an unknown ID appends.
+func insertTrack(tracks []Track, track Track, afterTrack string) []Track {
+	out := make([]Track, 0, len(tracks)+1)
+	if afterTrack == MPRIS_NO_TRACK {
+		return append(append(out, track), tracks...)
+	}
+
+	inserted := false
+	for _, t := range tracks {
+		out = append(out, t)
+		if !inserted && t.TrackID == afterTrack {
+			out = append(out, track)
+			inserted = true
+		}
+	}
+	if !inserted {
+		logger.Debug("[mpris] afterTrack %s not in cached tracklist, appending", afterTrack)
+		out = append(out, track)
+	}
+	return out
+}
+
+// RemoveTrackFromCache drops a track by ID (TrackRemoved signal); unknown ID is a no-op.
+func (m *MPRISBackend) RemoveTrackFromCache(busName, trackID string) error {
+	return m.mutateTracklist(busName, func(p *Player) bool {
+		for i := range p.Tracklist {
+			if p.Tracklist[i].TrackID == trackID {
+				out := make([]Track, 0, len(p.Tracklist)-1)
+				out = append(out, p.Tracklist[:i]...)
+				out = append(out, p.Tracklist[i+1:]...)
+				p.Tracklist = out
+				return true
+			}
+		}
+		return false
+	})
+}
+
+// UpdateTrackMetadataInCache replaces the track matching oldTrackID
+// (TrackMetadataChanged signal). The spec allows trackid renames, so the
+// stored ID comes from the new metadata when present.
+func (m *MPRISBackend) UpdateTrackMetadataInCache(busName, oldTrackID string, track Track) error {
+	return m.mutateTracklist(busName, func(p *Player) bool {
+		for i := range p.Tracklist {
+			if p.Tracklist[i].TrackID != oldTrackID {
+				continue
+			}
+			if track.TrackID == "" {
+				track.TrackID = oldTrackID
+			}
+			out := make([]Track, len(p.Tracklist))
+			copy(out, p.Tracklist)
+			out[i] = track
+			p.Tracklist = out
+			return true
+		}
+		return false
+	})
+}
+
+// UpdateCanEditTracks handles CanEditTracks arriving via PropertiesChanged.
+func (m *MPRISBackend) UpdateCanEditTracks(busName string, variant dbus.Variant) error {
+	val, ok := extractBool(variant)
+	if !ok {
+		return nil
+	}
+	return m.mutateTracklist(busName, func(p *Player) bool {
+		if p.CanEditTracks == val {
+			return false
+		}
+		p.CanEditTracks = val
+		return true
+	})
+}
+
+// tracklistPlayer fetches the cached player, rejecting players without
+// TrackList support.
+func (m *MPRISBackend) tracklistPlayer(busName string) (*Player, error) {
+	player, err := m.GetPlayerFromCache(busName)
+	if err != nil {
+		return nil, err
+	}
+	if !player.TracklistSupported {
+		return nil, &TracklistUnsupportedError{BusName: busName}
+	}
+	return player, nil
+}
+
+// editableTracklistPlayer is tracklistPlayer plus the CanEditTracks gate
+// required by edit operations.
+func (m *MPRISBackend) editableTracklistPlayer(busName string) (*Player, error) {
+	player, err := m.tracklistPlayer(busName)
+	if err != nil {
+		return nil, err
+	}
+	if !player.CanEditTracks {
+		return nil, &CapabilityError{Required: "CanEditTracks"}
+	}
+	return player, nil
+}
+
+// GetTracklist serves the cached tracklist; distinguishes "unsupported" (error,
+// →404) from "empty" (non-nil slice so JSON is [], not null).
+func (m *MPRISBackend) GetTracklist(busName string) (*TracklistResponse, error) {
+	player, err := m.tracklistPlayer(busName)
+	if err != nil {
+		return nil, err
+	}
+
+	tracks := player.Tracklist
+	if tracks == nil {
+		tracks = []Track{}
+	}
+	return &TracklistResponse{CanEditTracks: player.CanEditTracks, Tracks: tracks}, nil
+}
+
+// GoTo skips to the given track. Not gated on CanEditTracks: the spec doesn't
+// class GoTo as an edit operation.
+func (m *MPRISBackend) GoTo(busName, trackID string) error {
+	if _, err := m.tracklistPlayer(busName); err != nil {
+		return err
+	}
+	if !dbus.ObjectPath(trackID).IsValid() {
+		return &ValidationError{Field: "track_id", Message: "must be a valid D-Bus object path"}
+	}
+
+	logger.Debug("[mpris] going to track %s for %s", trackID, busName)
+	return m.callMethod(busName, MPRIS_METHOD_GO_TO, dbus.ObjectPath(trackID))
+}
+
+// AddTrack asks the player to add uri after afterTrack; empty afterTrack
+// appends after the last cached track (NoTrack sentinel when the list is empty).
+func (m *MPRISBackend) AddTrack(busName, uri, afterTrack string, setAsCurrent bool) error {
+	player, err := m.editableTracklistPlayer(busName)
+	if err != nil {
+		return err
+	}
+	if uri == "" {
+		return &ValidationError{Field: "uri", Message: "must not be empty"}
+	}
+
+	if afterTrack == "" {
+		if n := len(player.Tracklist); n > 0 {
+			afterTrack = player.Tracklist[n-1].TrackID
+		} else {
+			afterTrack = MPRIS_NO_TRACK
+		}
+	}
+	if !dbus.ObjectPath(afterTrack).IsValid() {
+		return &ValidationError{Field: "after_track", Message: "must be a valid D-Bus object path"}
+	}
+
+	logger.Debug("[mpris] adding track %s after %s for %s", uri, afterTrack, busName)
+	return m.callMethod(busName, MPRIS_METHOD_ADD_TRACK, uri, dbus.ObjectPath(afterTrack), setAsCurrent)
+}
+
+// RemoveTrack asks the player to remove a track from its tracklist.
+func (m *MPRISBackend) RemoveTrack(busName, trackID string) error {
+	if _, err := m.editableTracklistPlayer(busName); err != nil {
+		return err
+	}
+	if !dbus.ObjectPath(trackID).IsValid() {
+		return &ValidationError{Field: "track_id", Message: "must be a valid D-Bus object path"}
+	}
+
+	logger.Debug("[mpris] removing track %s for %s", trackID, busName)
+	return m.callMethod(busName, MPRIS_METHOD_REMOVE_TRACK, dbus.ObjectPath(trackID))
+}

--- a/backend/mpris/tracklist.go
+++ b/backend/mpris/tracklist.go
@@ -54,6 +54,21 @@ func tracklistEnvelope(p Player) map[string]any {
 	}
 }
 
+// tracklistMatches reports whether the player's cached tracklist has exactly
+// the given IDs in the same order.
+func (m *MPRISBackend) tracklistMatches(busName string, ids []dbus.ObjectPath) bool {
+	player, err := m.GetPlayerFromCache(busName)
+	if err != nil || len(player.Tracklist) != len(ids) {
+		return false
+	}
+	for i := range ids {
+		if player.Tracklist[i].TrackID != string(ids[i]) {
+			return false
+		}
+	}
+	return true
+}
+
 // ReplaceTracklist wholesale-replaces a player's tracklist (TrackListReplaced).
 func (m *MPRISBackend) ReplaceTracklist(busName string, tracks []Track) error {
 	return m.mutateTracklist(busName, func(p *Player) bool {

--- a/backend/mpris/tracklist.go
+++ b/backend/mpris/tracklist.go
@@ -168,7 +168,7 @@ func (m *MPRISBackend) UpdateTrackMetadataInCache(busName, oldTrackID string, tr
 
 // UpdateCanEditTracks handles CanEditTracks arriving via PropertiesChanged.
 func (m *MPRISBackend) UpdateCanEditTracks(busName string, variant dbus.Variant) error {
-	val, ok := extractBool(variant)
+	val, ok := extract[bool](variant)
 	if !ok {
 		return nil
 	}

--- a/backend/mpris/tracklist_test.go
+++ b/backend/mpris/tracklist_test.go
@@ -1,0 +1,127 @@
+package mpris
+
+import (
+	"testing"
+
+	"github.com/godbus/dbus/v5"
+)
+
+func TestTracksFromMetadata(t *testing.T) {
+	ids := []dbus.ObjectPath{
+		"/org/mpris/MediaPlayer2/track/1",
+		"/org/mpris/MediaPlayer2/track/2",
+		"/org/mpris/MediaPlayer2/track/3",
+	}
+	metas := []map[string]dbus.Variant{
+		{
+			"xesam:title":   dbus.MakeVariant("Song One"),
+			"xesam:artist":  dbus.MakeVariant([]string{"Artist A"}),
+			"mpris:trackid": dbus.MakeVariant(dbus.ObjectPath("/org/mpris/MediaPlayer2/track/1")),
+			"custom:key":    dbus.MakeVariant("should be whitelisted out"),
+		},
+		{
+			"xesam:title": dbus.MakeVariant("Song Two"),
+		},
+	}
+
+	tracks := tracksFromMetadata(ids, metas)
+
+	if len(tracks) != 3 {
+		t.Fatalf("len(tracks) = %d, want 3", len(tracks))
+	}
+	for i, id := range ids {
+		if tracks[i].TrackID != string(id) {
+			t.Errorf("tracks[%d].TrackID = %q, want %q", i, tracks[i].TrackID, id)
+		}
+	}
+	if tracks[0].Metadata["xesam:title"] != "Song One" {
+		t.Errorf("tracks[0] title = %q, want %q", tracks[0].Metadata["xesam:title"], "Song One")
+	}
+	if tracks[1].Metadata["xesam:title"] != "Song Two" {
+		t.Errorf("tracks[1] title = %q, want %q", tracks[1].Metadata["xesam:title"], "Song Two")
+	}
+	if _, ok := tracks[0].Metadata["custom:key"]; ok {
+		t.Error("non-whitelisted metadata key should be dropped")
+	}
+	// metas shorter than ids: trailing track has no metadata
+	if tracks[2].Metadata != nil {
+		t.Errorf("tracks[2].Metadata = %v, want nil", tracks[2].Metadata)
+	}
+}
+
+func TestTracksFromIDs(t *testing.T) {
+	ids := []dbus.ObjectPath{
+		"/org/mpris/MediaPlayer2/track/1",
+		"/org/mpris/MediaPlayer2/track/2",
+	}
+
+	tracks := tracksFromIDs(ids)
+
+	if len(tracks) != 2 {
+		t.Fatalf("len(tracks) = %d, want 2", len(tracks))
+	}
+	for i, id := range ids {
+		if tracks[i].TrackID != string(id) {
+			t.Errorf("tracks[%d].TrackID = %q, want %q", i, tracks[i].TrackID, id)
+		}
+		if tracks[i].Metadata != nil {
+			t.Errorf("tracks[%d].Metadata = %v, want nil", i, tracks[i].Metadata)
+		}
+	}
+
+	if got := tracksFromIDs(nil); len(got) != 0 {
+		t.Errorf("tracksFromIDs(nil) = %v, want empty", got)
+	}
+}
+
+func TestTrackFromSignalMetadata(t *testing.T) {
+	tests := []struct {
+		name        string
+		meta        map[string]dbus.Variant
+		wantTrackID string
+		wantTitle   string
+	}{
+		{
+			name: "trackid as ObjectPath variant",
+			meta: map[string]dbus.Variant{
+				"mpris:trackid": dbus.MakeVariant(dbus.ObjectPath("/org/mpris/MediaPlayer2/track/7")),
+				"xesam:title":   dbus.MakeVariant("Signal Song"),
+			},
+			wantTrackID: "/org/mpris/MediaPlayer2/track/7",
+			wantTitle:   "Signal Song",
+		},
+		{
+			name: "trackid as plain string is not accepted as ID",
+			meta: map[string]dbus.Variant{
+				"mpris:trackid": dbus.MakeVariant("/org/mpris/MediaPlayer2/track/7"),
+			},
+			wantTrackID: "",
+		},
+		{
+			name:        "missing trackid",
+			meta:        map[string]dbus.Variant{"xesam:title": dbus.MakeVariant("No ID")},
+			wantTrackID: "",
+			wantTitle:   "No ID",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			track := trackFromSignalMetadata(tt.meta)
+			if track.TrackID != tt.wantTrackID {
+				t.Errorf("TrackID = %q, want %q", track.TrackID, tt.wantTrackID)
+			}
+			if tt.wantTitle != "" && track.Metadata["xesam:title"] != tt.wantTitle {
+				t.Errorf("title = %q, want %q", track.Metadata["xesam:title"], tt.wantTitle)
+			}
+		})
+	}
+}
+
+func TestTracklistUnsupportedError(t *testing.T) {
+	err := &TracklistUnsupportedError{BusName: "org.mpris.MediaPlayer2.spotify"}
+	expected := "tracklist not supported: org.mpris.MediaPlayer2.spotify"
+	if err.Error() != expected {
+		t.Errorf("TracklistUnsupportedError.Error() = %q, want %q", err.Error(), expected)
+	}
+}

--- a/backend/mpris/tracklist_test.go
+++ b/backend/mpris/tracklist_test.go
@@ -444,6 +444,122 @@ func TestRemoveTrackValidation(t *testing.T) {
 	})
 }
 
+func TestListenerTracklistSignals(t *testing.T) {
+	const uniqueName = ":1.42"
+
+	newListener := func() (*Listener, *MPRISBackend) {
+		b := newTracklistBackend(Player{
+			BusName:            testBus,
+			uniqueName:         uniqueName,
+			TracklistSupported: true,
+			Tracklist:          []Track{{TrackID: "/track/1"}, {TrackID: "/track/2"}},
+		})
+		return &Listener{backend: b}, b
+	}
+
+	signal := func(name string, body ...interface{}) *dbus.Signal {
+		return &dbus.Signal{Sender: uniqueName, Path: MPRIS_PATH, Name: name, Body: body}
+	}
+
+	t.Run("TrackAdded prepends via NoTrack", func(t *testing.T) {
+		l, b := newListener()
+		meta := map[string]dbus.Variant{
+			"mpris:trackid": dbus.MakeVariant(dbus.ObjectPath("/track/new")),
+		}
+		l.handleSignal(signal(MPRIS_SIGNAL_TRACK_ADDED, meta, dbus.ObjectPath(MPRIS_NO_TRACK)))
+
+		p, _ := b.GetPlayerFromCache(testBus)
+		assertTrackIDs(t, p.Tracklist, []string{"/track/new", "/track/1", "/track/2"})
+	})
+
+	t.Run("TrackRemoved", func(t *testing.T) {
+		l, b := newListener()
+		l.handleSignal(signal(MPRIS_SIGNAL_TRACK_REMOVED, dbus.ObjectPath("/track/1")))
+
+		p, _ := b.GetPlayerFromCache(testBus)
+		assertTrackIDs(t, p.Tracklist, []string{"/track/2"})
+	})
+
+	t.Run("TrackMetadataChanged", func(t *testing.T) {
+		l, b := newListener()
+		meta := map[string]dbus.Variant{
+			"mpris:trackid": dbus.MakeVariant(dbus.ObjectPath("/track/1")),
+			"xesam:title":   dbus.MakeVariant("Fresh"),
+		}
+		l.handleSignal(signal(MPRIS_SIGNAL_TRACK_METADATA_CHANGED, dbus.ObjectPath("/track/1"), meta))
+
+		p, _ := b.GetPlayerFromCache(testBus)
+		if p.Tracklist[0].Metadata["xesam:title"] != "Fresh" {
+			t.Errorf("title = %q, want %q", p.Tracklist[0].Metadata["xesam:title"], "Fresh")
+		}
+	})
+
+	t.Run("TrackListReplaced with empty list clears", func(t *testing.T) {
+		l, b := newListener()
+		l.handleSignal(signal(MPRIS_SIGNAL_TRACKLIST_REPLACED, []dbus.ObjectPath{}, dbus.ObjectPath(MPRIS_NO_TRACK)))
+
+		p, _ := b.GetPlayerFromCache(testBus)
+		assertTrackIDs(t, p.Tracklist, []string{})
+	})
+
+	t.Run("unknown sender is dropped", func(t *testing.T) {
+		l, b := newListener()
+		sig := signal(MPRIS_SIGNAL_TRACK_REMOVED, dbus.ObjectPath("/track/1"))
+		sig.Sender = ":9.99"
+		l.handleSignal(sig)
+
+		p, _ := b.GetPlayerFromCache(testBus)
+		assertTrackIDs(t, p.Tracklist, []string{"/track/1", "/track/2"})
+	})
+
+	t.Run("malformed bodies are ignored", func(t *testing.T) {
+		l, b := newListener()
+		l.handleSignal(signal(MPRIS_SIGNAL_TRACK_ADDED, "not-a-map"))
+		l.handleSignal(signal(MPRIS_SIGNAL_TRACK_REMOVED))
+		l.handleSignal(signal(MPRIS_SIGNAL_TRACKLIST_REPLACED, "not-ids", dbus.ObjectPath("/x")))
+
+		p, _ := b.GetPlayerFromCache(testBus)
+		assertTrackIDs(t, p.Tracklist, []string{"/track/1", "/track/2"})
+	})
+
+	t.Run("PropertiesChanged on TrackList iface updates CanEditTracks", func(t *testing.T) {
+		l, b := newListener()
+		// Tracks matching the cache must be skipped (dedup for players that
+		// emit both TrackListReplaced and the property change): with a nil
+		// conn, going through the refresh would panic on the metadata fetch.
+		l.handleSignal(signal(DBUS_PROP_CHANGED_SIGNAL, MPRIS_TRACKLIST_IFACE, map[string]dbus.Variant{
+			"CanEditTracks": dbus.MakeVariant(true),
+			"Tracks":        dbus.MakeVariant([]dbus.ObjectPath{"/track/1", "/track/2"}),
+		}, []string{}))
+
+		p, _ := b.GetPlayerFromCache(testBus)
+		if !p.CanEditTracks {
+			t.Error("CanEditTracks should be true")
+		}
+		assertTrackIDs(t, p.Tracklist, []string{"/track/1", "/track/2"})
+	})
+
+	t.Run("PropertiesChanged with changed Tracks refreshes the list (VLC style)", func(t *testing.T) {
+		l, b := newListener()
+		l.handleSignal(signal(DBUS_PROP_CHANGED_SIGNAL, MPRIS_TRACKLIST_IFACE, map[string]dbus.Variant{
+			"Tracks": dbus.MakeVariant([]dbus.ObjectPath{}),
+		}, []string{}))
+
+		p, _ := b.GetPlayerFromCache(testBus)
+		assertTrackIDs(t, p.Tracklist, []string{})
+	})
+
+	t.Run("unrelated invalidated property does not refetch", func(t *testing.T) {
+		l, b := newListener()
+		// With a nil conn, a refetch would panic — not reaching D-Bus is the assertion.
+		l.handleSignal(signal(DBUS_PROP_CHANGED_SIGNAL, MPRIS_TRACKLIST_IFACE,
+			map[string]dbus.Variant{}, []string{"CanEditTracks"}))
+
+		p, _ := b.GetPlayerFromCache(testBus)
+		assertTrackIDs(t, p.Tracklist, []string{"/track/1", "/track/2"})
+	})
+}
+
 func TestTracklistUnsupportedError(t *testing.T) {
 	err := &TracklistUnsupportedError{BusName: "org.mpris.MediaPlayer2.spotify"}
 	expected := "tracklist not supported: org.mpris.MediaPlayer2.spotify"

--- a/backend/mpris/tracklist_test.go
+++ b/backend/mpris/tracklist_test.go
@@ -1,6 +1,7 @@
 package mpris
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/godbus/dbus/v5"
@@ -116,6 +117,331 @@ func TestTrackFromSignalMetadata(t *testing.T) {
 			}
 		})
 	}
+}
+
+const testBus = "org.mpris.MediaPlayer2.test"
+
+func newTracklistBackend(players ...Player) *MPRISBackend {
+	b := &MPRISBackend{}
+	b.players.Store(players)
+	return b
+}
+
+func trackIDs(tracks []Track) []string {
+	ids := make([]string, len(tracks))
+	for i, tr := range tracks {
+		ids[i] = tr.TrackID
+	}
+	return ids
+}
+
+func assertTrackIDs(t *testing.T, got []Track, want []string) {
+	t.Helper()
+	gotIDs := trackIDs(got)
+	if len(gotIDs) != len(want) {
+		t.Fatalf("track IDs = %v, want %v", gotIDs, want)
+	}
+	for i := range want {
+		if gotIDs[i] != want[i] {
+			t.Fatalf("track IDs = %v, want %v", gotIDs, want)
+		}
+	}
+}
+
+func TestReplaceTracklist(t *testing.T) {
+	b := newTracklistBackend(Player{BusName: testBus})
+
+	tracks := []Track{{TrackID: "/track/1"}, {TrackID: "/track/2"}}
+	if err := b.ReplaceTracklist(testBus, tracks); err != nil {
+		t.Fatalf("ReplaceTracklist failed: %v", err)
+	}
+
+	p, err := b.GetPlayerFromCache(testBus)
+	if err != nil {
+		t.Fatalf("GetPlayerFromCache: %v", err)
+	}
+	if !p.TracklistSupported {
+		t.Error("ReplaceTracklist should mark the player as tracklist-supported")
+	}
+	assertTrackIDs(t, p.Tracklist, []string{"/track/1", "/track/2"})
+
+	if err := b.ReplaceTracklist("org.mpris.MediaPlayer2.unknown", tracks); err == nil {
+		t.Error("ReplaceTracklist on unknown player should error")
+	}
+}
+
+func TestAddTrackToCache(t *testing.T) {
+	initial := []Track{{TrackID: "/track/1"}, {TrackID: "/track/2"}}
+	newTrack := Track{TrackID: "/track/new"}
+
+	tests := []struct {
+		name       string
+		busName    string
+		afterTrack string
+		wantIDs    []string
+		wantErr    bool
+	}{
+		{
+			name:       "prepend via NoTrack sentinel",
+			busName:    testBus,
+			afterTrack: MPRIS_NO_TRACK,
+			wantIDs:    []string{"/track/new", "/track/1", "/track/2"},
+		},
+		{
+			name:       "insert after existing track",
+			busName:    testBus,
+			afterTrack: "/track/1",
+			wantIDs:    []string{"/track/1", "/track/new", "/track/2"},
+		},
+		{
+			name:       "unknown afterTrack appends",
+			busName:    testBus,
+			afterTrack: "/track/ghost",
+			wantIDs:    []string{"/track/1", "/track/2", "/track/new"},
+		},
+		{
+			name:       "unknown player errors",
+			busName:    "org.mpris.MediaPlayer2.unknown",
+			afterTrack: MPRIS_NO_TRACK,
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := newTracklistBackend(Player{
+				BusName:   testBus,
+				Tracklist: append([]Track{}, initial...),
+			})
+
+			err := b.AddTrackToCache(tt.busName, newTrack, tt.afterTrack)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("AddTrackToCache error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+
+			p, _ := b.GetPlayerFromCache(testBus)
+			if !p.TracklistSupported {
+				t.Error("AddTrackToCache should mark the player as tracklist-supported")
+			}
+			assertTrackIDs(t, p.Tracklist, tt.wantIDs)
+		})
+	}
+}
+
+func TestRemoveTrackFromCache(t *testing.T) {
+	b := newTracklistBackend(Player{
+		BusName:   testBus,
+		Tracklist: []Track{{TrackID: "/track/1"}, {TrackID: "/track/2"}},
+	})
+
+	if err := b.RemoveTrackFromCache(testBus, "/track/1"); err != nil {
+		t.Fatalf("RemoveTrackFromCache failed: %v", err)
+	}
+	p, _ := b.GetPlayerFromCache(testBus)
+	assertTrackIDs(t, p.Tracklist, []string{"/track/2"})
+
+	// Unknown ID is a no-op
+	if err := b.RemoveTrackFromCache(testBus, "/track/ghost"); err != nil {
+		t.Fatalf("RemoveTrackFromCache with unknown ID failed: %v", err)
+	}
+	p, _ = b.GetPlayerFromCache(testBus)
+	assertTrackIDs(t, p.Tracklist, []string{"/track/2"})
+}
+
+func TestUpdateTrackMetadataInCache(t *testing.T) {
+	newBackend := func() *MPRISBackend {
+		return newTracklistBackend(Player{
+			BusName: testBus,
+			Tracklist: []Track{
+				{TrackID: "/track/1", Metadata: map[string]string{"xesam:title": "Old"}},
+				{TrackID: "/track/2"},
+			},
+		})
+	}
+
+	t.Run("metadata updated, ID kept when new one is empty", func(t *testing.T) {
+		b := newBackend()
+		err := b.UpdateTrackMetadataInCache(testBus, "/track/1", Track{
+			Metadata: map[string]string{"xesam:title": "New"},
+		})
+		if err != nil {
+			t.Fatalf("UpdateTrackMetadataInCache failed: %v", err)
+		}
+		p, _ := b.GetPlayerFromCache(testBus)
+		assertTrackIDs(t, p.Tracklist, []string{"/track/1", "/track/2"})
+		if p.Tracklist[0].Metadata["xesam:title"] != "New" {
+			t.Errorf("title = %q, want %q", p.Tracklist[0].Metadata["xesam:title"], "New")
+		}
+	})
+
+	t.Run("trackid rename", func(t *testing.T) {
+		b := newBackend()
+		err := b.UpdateTrackMetadataInCache(testBus, "/track/1", Track{
+			TrackID:  "/track/renamed",
+			Metadata: map[string]string{"xesam:title": "New"},
+		})
+		if err != nil {
+			t.Fatalf("UpdateTrackMetadataInCache failed: %v", err)
+		}
+		p, _ := b.GetPlayerFromCache(testBus)
+		assertTrackIDs(t, p.Tracklist, []string{"/track/renamed", "/track/2"})
+	})
+
+	t.Run("unknown old ID is a no-op", func(t *testing.T) {
+		b := newBackend()
+		if err := b.UpdateTrackMetadataInCache(testBus, "/track/ghost", Track{TrackID: "/x"}); err != nil {
+			t.Fatalf("UpdateTrackMetadataInCache failed: %v", err)
+		}
+		p, _ := b.GetPlayerFromCache(testBus)
+		assertTrackIDs(t, p.Tracklist, []string{"/track/1", "/track/2"})
+	})
+}
+
+func TestUpdateCanEditTracks(t *testing.T) {
+	b := newTracklistBackend(Player{BusName: testBus, TracklistSupported: true})
+
+	if err := b.UpdateCanEditTracks(testBus, dbus.MakeVariant(true)); err != nil {
+		t.Fatalf("UpdateCanEditTracks failed: %v", err)
+	}
+	p, _ := b.GetPlayerFromCache(testBus)
+	if !p.CanEditTracks {
+		t.Error("CanEditTracks should be true")
+	}
+
+	// Non-bool variant is ignored
+	if err := b.UpdateCanEditTracks(testBus, dbus.MakeVariant("nope")); err != nil {
+		t.Fatalf("UpdateCanEditTracks with non-bool failed: %v", err)
+	}
+	p, _ = b.GetPlayerFromCache(testBus)
+	if !p.CanEditTracks {
+		t.Error("non-bool variant should not change CanEditTracks")
+	}
+}
+
+func TestGetTracklist(t *testing.T) {
+	t.Run("unsupported player", func(t *testing.T) {
+		b := newTracklistBackend(Player{BusName: testBus})
+		_, err := b.GetTracklist(testBus)
+		var unsupported *TracklistUnsupportedError
+		if !errors.As(err, &unsupported) {
+			t.Fatalf("GetTracklist error = %v, want TracklistUnsupportedError", err)
+		}
+	})
+
+	t.Run("supported with nil slice returns empty non-nil tracks", func(t *testing.T) {
+		b := newTracklistBackend(Player{BusName: testBus, TracklistSupported: true})
+		resp, err := b.GetTracklist(testBus)
+		if err != nil {
+			t.Fatalf("GetTracklist failed: %v", err)
+		}
+		if resp.Tracks == nil {
+			t.Error("Tracks should be non-nil so JSON is [] instead of null")
+		}
+		if len(resp.Tracks) != 0 {
+			t.Errorf("len(Tracks) = %d, want 0", len(resp.Tracks))
+		}
+	})
+
+	t.Run("full response", func(t *testing.T) {
+		b := newTracklistBackend(Player{
+			BusName:            testBus,
+			TracklistSupported: true,
+			CanEditTracks:      true,
+			Tracklist:          []Track{{TrackID: "/track/1"}},
+		})
+		resp, err := b.GetTracklist(testBus)
+		if err != nil {
+			t.Fatalf("GetTracklist failed: %v", err)
+		}
+		if !resp.CanEditTracks {
+			t.Error("CanEditTracks should be true")
+		}
+		assertTrackIDs(t, resp.Tracks, []string{"/track/1"})
+	})
+}
+
+// Action guard tests run with a nil D-Bus conn: any guard passing through
+// to callMethod would panic.
+
+func TestGoToValidation(t *testing.T) {
+	t.Run("unsupported player", func(t *testing.T) {
+		b := newTracklistBackend(Player{BusName: testBus})
+		var unsupported *TracklistUnsupportedError
+		if err := b.GoTo(testBus, "/track/1"); !errors.As(err, &unsupported) {
+			t.Errorf("GoTo error = %v, want TracklistUnsupportedError", err)
+		}
+	})
+
+	t.Run("invalid object path", func(t *testing.T) {
+		b := newTracklistBackend(Player{BusName: testBus, TracklistSupported: true})
+		var validation *ValidationError
+		if err := b.GoTo(testBus, "not-a-path"); !errors.As(err, &validation) {
+			t.Errorf("GoTo error = %v, want ValidationError", err)
+		}
+	})
+}
+
+func TestAddTrackValidation(t *testing.T) {
+	t.Run("unsupported player", func(t *testing.T) {
+		b := newTracklistBackend(Player{BusName: testBus})
+		var unsupported *TracklistUnsupportedError
+		if err := b.AddTrack(testBus, "file:///a.mp3", "", false); !errors.As(err, &unsupported) {
+			t.Errorf("AddTrack error = %v, want TracklistUnsupportedError", err)
+		}
+	})
+
+	t.Run("cannot edit tracks", func(t *testing.T) {
+		b := newTracklistBackend(Player{BusName: testBus, TracklistSupported: true})
+		var capability *CapabilityError
+		if err := b.AddTrack(testBus, "file:///a.mp3", "", false); !errors.As(err, &capability) {
+			t.Errorf("AddTrack error = %v, want CapabilityError", err)
+		}
+	})
+
+	t.Run("empty uri", func(t *testing.T) {
+		b := newTracklistBackend(Player{BusName: testBus, TracklistSupported: true, CanEditTracks: true})
+		var validation *ValidationError
+		if err := b.AddTrack(testBus, "", "", false); !errors.As(err, &validation) {
+			t.Errorf("AddTrack error = %v, want ValidationError", err)
+		}
+	})
+
+	t.Run("invalid afterTrack", func(t *testing.T) {
+		b := newTracklistBackend(Player{BusName: testBus, TracklistSupported: true, CanEditTracks: true})
+		var validation *ValidationError
+		if err := b.AddTrack(testBus, "file:///a.mp3", "not-a-path", false); !errors.As(err, &validation) {
+			t.Errorf("AddTrack error = %v, want ValidationError", err)
+		}
+	})
+}
+
+func TestRemoveTrackValidation(t *testing.T) {
+	t.Run("unsupported player", func(t *testing.T) {
+		b := newTracklistBackend(Player{BusName: testBus})
+		var unsupported *TracklistUnsupportedError
+		if err := b.RemoveTrack(testBus, "/track/1"); !errors.As(err, &unsupported) {
+			t.Errorf("RemoveTrack error = %v, want TracklistUnsupportedError", err)
+		}
+	})
+
+	t.Run("cannot edit tracks", func(t *testing.T) {
+		b := newTracklistBackend(Player{BusName: testBus, TracklistSupported: true})
+		var capability *CapabilityError
+		if err := b.RemoveTrack(testBus, "/track/1"); !errors.As(err, &capability) {
+			t.Errorf("RemoveTrack error = %v, want CapabilityError", err)
+		}
+	})
+
+	t.Run("invalid object path", func(t *testing.T) {
+		b := newTracklistBackend(Player{BusName: testBus, TracklistSupported: true, CanEditTracks: true})
+		var validation *ValidationError
+		if err := b.RemoveTrack(testBus, "not-a-path"); !errors.As(err, &validation) {
+			t.Errorf("RemoveTrack error = %v, want ValidationError", err)
+		}
+	})
 }
 
 func TestTracklistUnsupportedError(t *testing.T) {

--- a/backend/mpris/tracklist_test.go
+++ b/backend/mpris/tracklist_test.go
@@ -300,6 +300,37 @@ func TestUpdateTrackMetadataInCache(t *testing.T) {
 	})
 }
 
+func TestResolveTrackRef(t *testing.T) {
+	tracks := []Track{
+		{TrackID: "/org/mpris/MediaPlayer2/Track/7"},
+		{TrackID: "/org/videolan/vlc/playlist/17"},
+	}
+
+	tests := []struct {
+		name   string
+		ref    string
+		want   string
+		wantOk bool
+	}{
+		{name: "full object path", ref: "/org/mpris/MediaPlayer2/Track/7", want: "/org/mpris/MediaPlayer2/Track/7", wantOk: true},
+		{name: "last segment", ref: "17", want: "/org/videolan/vlc/playlist/17", wantOk: true},
+		{name: "unknown ref", ref: "99", wantOk: false},
+		{name: "partial path does not match", ref: "playlist/17", wantOk: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := resolveTrackRef(tracks, tt.ref)
+			if ok != tt.wantOk {
+				t.Fatalf("resolveTrackRef(%q) ok = %v, want %v", tt.ref, ok, tt.wantOk)
+			}
+			if got != tt.want {
+				t.Errorf("resolveTrackRef(%q) = %q, want %q", tt.ref, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestUpdateCanEditTracks(t *testing.T) {
 	b := newTracklistBackend(Player{BusName: testBus, TracklistSupported: true})
 
@@ -375,10 +406,10 @@ func TestGoToValidation(t *testing.T) {
 		}
 	})
 
-	t.Run("invalid object path", func(t *testing.T) {
+	t.Run("unknown track ref", func(t *testing.T) {
 		b := newTracklistBackend(Player{BusName: testBus, TracklistSupported: true})
 		var validation *ValidationError
-		if err := b.GoTo(testBus, "not-a-path"); !errors.As(err, &validation) {
+		if err := b.GoTo(testBus, "99"); !errors.As(err, &validation) {
 			t.Errorf("GoTo error = %v, want ValidationError", err)
 		}
 	})
@@ -409,10 +440,31 @@ func TestAddTrackValidation(t *testing.T) {
 		}
 	})
 
-	t.Run("invalid afterTrack", func(t *testing.T) {
+	t.Run("bare path uri (no scheme)", func(t *testing.T) {
 		b := newTracklistBackend(Player{BusName: testBus, TracklistSupported: true, CanEditTracks: true})
 		var validation *ValidationError
-		if err := b.AddTrack(testBus, "file:///a.mp3", "not-a-path", false); !errors.As(err, &validation) {
+		if err := b.AddTrack(testBus, "B' Side/track.mp3", "", false); !errors.As(err, &validation) {
+			t.Errorf("AddTrack error = %v, want ValidationError", err)
+		}
+	})
+
+	t.Run("scheme not in SupportedUriSchemes", func(t *testing.T) {
+		b := newTracklistBackend(Player{
+			BusName:             testBus,
+			TracklistSupported:  true,
+			CanEditTracks:       true,
+			SupportedUriSchemes: []string{"file"},
+		})
+		var validation *ValidationError
+		if err := b.AddTrack(testBus, "http://example.com/a.mp3", "", false); !errors.As(err, &validation) {
+			t.Errorf("AddTrack error = %v, want ValidationError", err)
+		}
+	})
+
+	t.Run("unknown afterTrack", func(t *testing.T) {
+		b := newTracklistBackend(Player{BusName: testBus, TracklistSupported: true, CanEditTracks: true})
+		var validation *ValidationError
+		if err := b.AddTrack(testBus, "file:///a.mp3", "99", false); !errors.As(err, &validation) {
 			t.Errorf("AddTrack error = %v, want ValidationError", err)
 		}
 	})
@@ -435,10 +487,10 @@ func TestRemoveTrackValidation(t *testing.T) {
 		}
 	})
 
-	t.Run("invalid object path", func(t *testing.T) {
+	t.Run("unknown track ref", func(t *testing.T) {
 		b := newTracklistBackend(Player{BusName: testBus, TracklistSupported: true, CanEditTracks: true})
 		var validation *ValidationError
-		if err := b.RemoveTrack(testBus, "not-a-path"); !errors.As(err, &validation) {
+		if err := b.RemoveTrack(testBus, "99"); !errors.As(err, &validation) {
 			t.Errorf("RemoveTrack error = %v, want ValidationError", err)
 		}
 	})

--- a/backend/mpris/types.go
+++ b/backend/mpris/types.go
@@ -57,16 +57,17 @@ type Player struct {
 
 	BusName string `json:"bus_name"`
 
-	Identity          string            `json:"identity" dbus:"Identity" iface:"org.mpris.MediaPlayer2"`
-	PlaybackStatus    PlaybackStatus    `json:"playback_status" dbus:"PlaybackStatus" iface:"org.mpris.MediaPlayer2.Player"`
-	LoopStatus        LoopStatus        `json:"loop_status,omitempty" dbus:"LoopStatus" iface:"org.mpris.MediaPlayer2.Player"`
-	Shuffle           bool              `json:"shuffle,omitempty" dbus:"Shuffle" iface:"org.mpris.MediaPlayer2.Player"`
-	Volume            *float64          `json:"volume,omitempty" dbus:"Volume" iface:"org.mpris.MediaPlayer2.Player"`
-	Position          int64             `json:"position,omitempty" dbus:"Position" iface:"org.mpris.MediaPlayer2.Player"`
-	PositionUpdatedAt time.Time         `json:"position_updated_at"`
-	Rate              float64           `json:"rate,omitempty" dbus:"Rate" iface:"org.mpris.MediaPlayer2.Player"`
-	Metadata          map[string]string `json:"metadata,omitempty" dbus:"Metadata" iface:"org.mpris.MediaPlayer2.Player"`
-	Capabilities      Capabilities      `json:"capabilities"`
+	Identity            string            `json:"identity" dbus:"Identity" iface:"org.mpris.MediaPlayer2"`
+	SupportedUriSchemes []string          `json:"-" dbus:"SupportedUriSchemes" iface:"org.mpris.MediaPlayer2"`
+	PlaybackStatus      PlaybackStatus    `json:"playback_status" dbus:"PlaybackStatus" iface:"org.mpris.MediaPlayer2.Player"`
+	LoopStatus          LoopStatus        `json:"loop_status,omitempty" dbus:"LoopStatus" iface:"org.mpris.MediaPlayer2.Player"`
+	Shuffle             bool              `json:"shuffle,omitempty" dbus:"Shuffle" iface:"org.mpris.MediaPlayer2.Player"`
+	Volume              *float64          `json:"volume,omitempty" dbus:"Volume" iface:"org.mpris.MediaPlayer2.Player"`
+	Position            int64             `json:"position,omitempty" dbus:"Position" iface:"org.mpris.MediaPlayer2.Player"`
+	PositionUpdatedAt   time.Time         `json:"position_updated_at"`
+	Rate                float64           `json:"rate,omitempty" dbus:"Rate" iface:"org.mpris.MediaPlayer2.Player"`
+	Metadata            map[string]string `json:"metadata,omitempty" dbus:"Metadata" iface:"org.mpris.MediaPlayer2.Player"`
+	Capabilities        Capabilities      `json:"capabilities"`
 
 	// No dbus:/iface: tags: TrackList is optional, loaded by a separate
 	// non-fatal step outside the reflection loop whose GetAll failures are fatal.
@@ -123,12 +124,6 @@ type ShuffleRequest struct {
 type TracklistResponse struct {
 	CanEditTracks bool    `json:"can_edit_tracks"`
 	Tracks        []Track `json:"tracks"`
-}
-
-// Shared by GoTo and RemoveTrack. Body instead of a path param:
-// track IDs are object paths containing "/"
-type TrackRequest struct {
-	TrackID string `json:"track_id"`
 }
 
 type AddTrackRequest struct {

--- a/backend/mpris/types.go
+++ b/backend/mpris/types.go
@@ -23,8 +23,10 @@ type MPRISBackend struct {
 	ctx     context.Context
 	timeout time.Duration
 
-	// permanent cache (no expiration)
-	cache *cache.Cache[[]Player]
+	// Players cache: readers take lock-free immutable snapshots (nil = never
+	// loaded); writers copy-on-write, serialized through updatePlayers.
+	players   cache.Value[[]Player]
+	playersMu sync.Mutex
 
 	// listener for MPRIS changes
 	listener *Listener

--- a/backend/mpris/types.go
+++ b/backend/mpris/types.go
@@ -65,6 +65,18 @@ type Player struct {
 	Rate              float64           `json:"rate,omitempty" dbus:"Rate" iface:"org.mpris.MediaPlayer2.Player"`
 	Metadata          map[string]string `json:"metadata,omitempty" dbus:"Metadata" iface:"org.mpris.MediaPlayer2.Player"`
 	Capabilities      Capabilities      `json:"capabilities"`
+
+	// No dbus:/iface: tags: TrackList is optional, loaded by a separate
+	// non-fatal step outside the reflection loop whose GetAll failures are fatal.
+	TracklistSupported bool    `json:"tracklist_supported"`
+	CanEditTracks      bool    `json:"-"`
+	Tracklist          []Track `json:"-"` // served by the dedicated /tracklist endpoint
+}
+
+// Track represents an entry in a player's tracklist
+type Track struct {
+	TrackID  string            `json:"track_id"`
+	Metadata map[string]string `json:"metadata,omitempty"`
 }
 
 // Capabilities represents the actions supported by a player
@@ -104,4 +116,21 @@ type LoopRequest struct {
 
 type ShuffleRequest struct {
 	Shuffle bool `json:"shuffle"`
+}
+
+type TracklistResponse struct {
+	CanEditTracks bool    `json:"can_edit_tracks"`
+	Tracks        []Track `json:"tracks"`
+}
+
+// Shared by GoTo and RemoveTrack. Body instead of a path param:
+// track IDs are object paths containing "/"
+type TrackRequest struct {
+	TrackID string `json:"track_id"`
+}
+
+type AddTrackRequest struct {
+	Uri          string `json:"uri"`
+	AfterTrack   string `json:"after_track,omitempty"` // empty = append at end
+	SetAsCurrent bool   `json:"set_as_current,omitempty"`
 }

--- a/events/events.go
+++ b/events/events.go
@@ -6,6 +6,7 @@ const (
 	TypePlayerAdded         = "player.added"
 	TypePlayerRemoved       = "player.removed"
 	TypePlayerPosition      = "player.position"
+	TypePlayerTracklist     = "player.tracklist.updated"
 	TypeAudioUpdated        = "audio.updated"
 	TypeAudioRemoved        = "audio.removed"
 	TypeAudioOutputUpdated  = "audio.output.updated"
@@ -36,7 +37,7 @@ type Stream interface {
 
 // BackendTypes maps backend names to their event type constants.
 var BackendTypes = map[string][]string{
-	"mpris":     {TypePlayerUpdated, TypePlayerAdded, TypePlayerRemoved, TypePlayerPosition},
+	"mpris":     {TypePlayerUpdated, TypePlayerAdded, TypePlayerRemoved, TypePlayerPosition, TypePlayerTracklist},
 	"audio":     {TypeAudioUpdated, TypeAudioRemoved, TypeAudioOutputUpdated, TypeAudioOutputRemoved},
 	"systemd":   {TypeServiceUpdated},
 	"bluetooth": {TypeBluetoothUpdated, TypeBluetoothDiscovered},


### PR DESCRIPTION
Probe the optional org.mpris.MediaPlayer2.TrackList interface when loading a player: non-fatal, players without it load exactly as before. Tracks and CanEditTracks live on the cached Player (JSON-hidden, for the upcoming /tracklist endpoint); only tracklist_supported is exposed. Metadata is fetched with a single GetTracksMetadata call, falling back to IDs-only tracks. Also subscribe to TrackList signals via an interface+path match rule (arg0namespace can't match: arg0 is 'ao').


Claude-Session: https://claude.ai/code/session_01Sathks1sgo6iJF16zpiewx