### PR TITLE
feat(ui): fullscreen zoom on the player cover

### DIFF
--- a/ui/client.go
+++ b/ui/client.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"path"
 	"sort"
 	"strconv"
 	"strings"
@@ -61,7 +62,58 @@ func (c *APIClient) GetPlayers() ([]PlayerView, error) {
 	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
 		return nil, fmt.Errorf("/players: decode failed: %w", err)
 	}
-	return convertPlayers(raw), nil
+	views := convertPlayers(raw)
+	c.attachTracklists(raw, views)
+	return views, nil
+}
+
+// attachTracklists fetches the tracklist of each supporting player and fills
+// the matching view. Failures only cost the tracklist, not the section.
+func (c *APIClient) attachTracklists(raw []Player, views []PlayerView) {
+	supported := make(map[string]*Player, len(raw))
+	for i := range raw {
+		if raw[i].TracklistSupported {
+			supported[raw[i].Name] = &raw[i]
+		}
+	}
+	for i := range views {
+		p, ok := supported[views[i].Name]
+		if !ok {
+			continue
+		}
+		tl, err := c.GetTracklist(p.Name)
+		if err != nil {
+			logger.Warn("[ui] failed to fetch tracklist for %s: %v", p.Name, err)
+			continue
+		}
+		views[i].CanEditTracks = tl.CanEditTracks
+		views[i].Tracks = convertTracks(tl.Tracks, p.Metadata["mpris:trackid"])
+	}
+}
+
+func (c *APIClient) GetTracklist(name string) (*TracklistResponse, error) {
+	var v TracklistResponse
+	if err := c.get("/players/"+name+"/tracklist", &v); err != nil {
+		return nil, err
+	}
+	return &v, nil
+}
+
+func convertTracks(tracks []Track, currentID string) []TrackView {
+	views := make([]TrackView, 0, len(tracks))
+	for _, t := range tracks {
+		label := t.Metadata["xesam:title"]
+		if label == "" {
+			label = path.Base(t.TrackID)
+		}
+		views = append(views, TrackView{
+			Ref:     url.PathEscape(t.TrackID),
+			Label:   label,
+			Artist:  t.Metadata["xesam:artist"],
+			Current: t.TrackID == currentID,
+		})
+	}
+	return views
 }
 
 func convertPlayers(raw []Player) []PlayerView {

--- a/ui/handler.go
+++ b/ui/handler.go
@@ -295,9 +295,10 @@ var (
 	upgradeRingSection = &sseSection{name: "upgrade-progress", fetchFn: fetchUpgradeRing}
 
 	eventToSection = map[string]*sseSection{
-		events.TypePlayerUpdated: mprisSection,
-		events.TypePlayerAdded:   mprisSection,
-		events.TypePlayerRemoved: mprisSection,
+		events.TypePlayerUpdated:   mprisSection,
+		events.TypePlayerAdded:     mprisSection,
+		events.TypePlayerRemoved:   mprisSection,
+		events.TypePlayerTracklist: mprisSection,
 		// player.position is intentionally NOT mapped here: re-rendering the
 		// whole section every heartbeat tick (5s) made the card flicker. The
 		// seeker is interpolated client-side from data-position +

--- a/ui/handler_test.go
+++ b/ui/handler_test.go
@@ -889,3 +889,160 @@ func TestConvertServices(t *testing.T) {
 		})
 	}
 }
+
+// TestConvertTracks verifies label fallback, path-escaped refs and
+// current-track matching.
+func TestConvertTracks(t *testing.T) {
+	tracks := []Track{
+		{TrackID: "/org/mpd/track/1", Metadata: map[string]string{"xesam:title": "Song One", "xesam:artist": "Artist"}},
+		{TrackID: "/org/mpd/track/2", Metadata: map[string]string{}},
+	}
+
+	result := convertTracks(tracks, "/org/mpd/track/2")
+	if len(result) != 2 {
+		t.Fatalf("expected 2 tracks, got %d", len(result))
+	}
+	if result[0].Label != "Song One" {
+		t.Errorf("expected title label 'Song One', got %q", result[0].Label)
+	}
+	if result[0].Artist != "Artist" {
+		t.Errorf("expected artist 'Artist', got %q", result[0].Artist)
+	}
+	if result[0].Ref != "%2Forg%2Fmpd%2Ftrack%2F1" {
+		t.Errorf("expected path-escaped full ID ref, got %q", result[0].Ref)
+	}
+	if result[1].Label != "2" {
+		t.Errorf("expected ID last-segment fallback label '2', got %q", result[1].Label)
+	}
+	if result[0].Current || !result[1].Current {
+		t.Errorf("expected only track 2 current, got %v/%v", result[0].Current, result[1].Current)
+	}
+}
+
+// TestShowTracklist verifies the toggle threshold: below 2 tracks the
+// tracklist view offers nothing over the cover.
+func TestShowTracklist(t *testing.T) {
+	for count, want := range map[int]bool{0: false, 1: false, 2: true, 3: true} {
+		v := PlayerView{Tracks: make([]TrackView, count)}
+		if v.ShowTracklist() != want {
+			t.Errorf("ShowTracklist with %d tracks: expected %v", count, want)
+		}
+	}
+}
+
+// TestGetPlayersAttachesTracklists verifies that supporting players get their
+// tracklist fetched and converted, non-supporting players are left alone, and
+// a tracklist fetch failure costs only the tracklist, not the players call.
+func TestGetPlayersAttachesTracklists(t *testing.T) {
+	playersJSON := `[
+		{"bus_name": "org.mpris.MediaPlayer2.mpd", "playback_status": "Playing",
+		 "tracklist_supported": true,
+		 "metadata": {"mpris:trackid": "/org/mpd/track/2"}},
+		{"bus_name": "org.mpris.MediaPlayer2.spotify", "playback_status": "Playing",
+		 "metadata": {}},
+		{"bus_name": "org.mpris.MediaPlayer2.broken", "playback_status": "Playing",
+		 "tracklist_supported": true,
+		 "metadata": {}}
+	]`
+	tracklistJSON := `{"can_edit_tracks": true, "tracks": [
+		{"track_id": "/org/mpd/track/1", "metadata": {"xesam:title": "One"}},
+		{"track_id": "/org/mpd/track/2", "metadata": {"xesam:title": "Two"}}
+	]}`
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/players", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := w.Write([]byte(playersJSON)); err != nil {
+			t.Errorf("write players: %v", err)
+		}
+	})
+	mux.HandleFunc("/players/org.mpris.MediaPlayer2.mpd/tracklist", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := w.Write([]byte(tracklistJSON)); err != nil {
+			t.Errorf("write tracklist: %v", err)
+		}
+	})
+	mux.HandleFunc("/players/org.mpris.MediaPlayer2.broken/tracklist", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	views, err := NewAPIClient(testAPIPort(t, server)).GetPlayers()
+	if err != nil {
+		t.Fatalf("GetPlayers failed: %v", err)
+	}
+	if len(views) != 3 {
+		t.Fatalf("expected 3 players, got %d", len(views))
+	}
+
+	mpd := views[0]
+	if !mpd.CanEditTracks {
+		t.Error("expected mpd CanEditTracks true")
+	}
+	if len(mpd.Tracks) != 2 {
+		t.Fatalf("expected 2 mpd tracks, got %d", len(mpd.Tracks))
+	}
+	if mpd.Tracks[0].Current || !mpd.Tracks[1].Current {
+		t.Errorf("expected only track 2 current, got %v/%v", mpd.Tracks[0].Current, mpd.Tracks[1].Current)
+	}
+	if len(views[1].Tracks) != 0 {
+		t.Errorf("expected no tracks for non-supporting player, got %d", len(views[1].Tracks))
+	}
+	if len(views[2].Tracks) != 0 || views[2].CanEditTracks {
+		t.Errorf("expected failed tracklist fetch to leave player untouched, got %d tracks", len(views[2].Tracks))
+	}
+}
+
+// TestMprisPlayerTracklistRendering verifies the toggle and tracklist only
+// render with at least 2 tracks, and remove buttons only when editable.
+func TestMprisPlayerTracklistRendering(t *testing.T) {
+	tmpl := LoadTemplates()
+	twoTracks := []TrackView{
+		{Ref: "%2Fa%2F1", Label: "One", Current: true},
+		{Ref: "%2Fa%2F2", Label: "Two"},
+	}
+
+	render := func(t *testing.T, v PlayerView) string {
+		t.Helper()
+		var buf bytes.Buffer
+		if err := tmpl.ExecuteTemplate(&buf, "mpris-player", v); err != nil {
+			t.Fatalf("render failed: %v", err)
+		}
+		return buf.String()
+	}
+
+	t.Run("editable tracklist renders toggle, rows and removes", func(t *testing.T) {
+		html := render(t, PlayerView{Name: "p", State: "Playing", Tracks: twoTracks, CanEditTracks: true})
+		for _, want := range []string{
+			"player-view-toggle",
+			"tracklist-current",
+			"tracklist-remove",
+			`hx-post="/players/p/tracklist/goto/%2Fa%2F1"`,
+			`hx-post="/players/p/tracklist/remove/%2Fa%2F2"`,
+		} {
+			if !strings.Contains(html, want) {
+				t.Errorf("expected rendered card to contain %q", want)
+			}
+		}
+	})
+
+	t.Run("read-only tracklist has no remove buttons", func(t *testing.T) {
+		html := render(t, PlayerView{Name: "p", State: "Playing", Tracks: twoTracks})
+		if !strings.Contains(html, "tracklist-goto") {
+			t.Error("expected tracklist rows")
+		}
+		if strings.Contains(html, "tracklist-remove") {
+			t.Error("expected no remove buttons when CanEditTracks is false")
+		}
+	})
+
+	t.Run("single track renders neither toggle nor tracklist", func(t *testing.T) {
+		html := render(t, PlayerView{Name: "p", State: "Playing", Tracks: twoTracks[:1]})
+		for _, banned := range []string{"player-view-toggle", "tracklist-goto"} {
+			if strings.Contains(html, banned) {
+				t.Errorf("expected no %q with a single track", banned)
+			}
+		}
+	})
+}

--- a/ui/static/odio.js
+++ b/ui/static/odio.js
@@ -67,6 +67,28 @@ document.body.addEventListener('htmx:sendError', () => {
 	showToast('Network error');
 });
 
+// ── Cover zoom ──────────────────────────────────────────────────────────────
+
+// Fullscreen lightbox for a player cover. The overlay lives in base.gohtml,
+// outside the SSE-swapped sections, so it survives section re-renders.
+function openArtZoom(img) {
+	const overlay = document.getElementById('art-overlay');
+	if (!overlay) return;
+	overlay.querySelector('img').src = img.src;
+	overlay.classList.remove('hidden');
+}
+
+function closeArtZoom() {
+	const overlay = document.getElementById('art-overlay');
+	if (!overlay) return;
+	overlay.classList.add('hidden');
+	overlay.querySelector('img').removeAttribute('src');
+}
+
+document.addEventListener('keydown', e => {
+	if (e.key === 'Escape') closeArtZoom();
+});
+
 // ── Transport buttons ───────────────────────────────────────────────────────
 
 // Both icons live in the button as <span>; group-data-[playing=true]: variants

--- a/ui/static/odio.js
+++ b/ui/static/odio.js
@@ -97,6 +97,7 @@ document.addEventListener('keydown', e => {
 // detailsState; the entry is dropped when the tracklist no longer renders
 // (shrunk below 2 tracks) so the card can't restore into an empty slot.
 var tracklistViews = {};
+var tracklistScroll = {};
 
 function toggleTracklistView(btn) {
 	const card = btn.closest('.player-card');
@@ -104,6 +105,16 @@ function toggleTracklistView(btn) {
 	card.dataset.view = next;
 	tracklistViews[card.id] = next;
 }
+
+// Swaps recreate the scroll container, so capture each tracklist's scrollTop
+// before the message and reapply it after the view is restored (a hidden
+// element has no scroll box — order matters).
+document.addEventListener('htmx:sseBeforeMessage', function() {
+	document.querySelectorAll('.player-card .tracklist').forEach(function(el) {
+		const card = el.closest('.player-card');
+		if (card) tracklistScroll[card.id] = el.scrollTop;
+	});
+});
 
 document.addEventListener('htmx:afterSwap', function() {
 	Object.keys(tracklistViews).forEach(function(id) {
@@ -113,6 +124,15 @@ document.addEventListener('htmx:afterSwap', function() {
 			card.dataset.view = tracklistViews[id];
 		} else {
 			delete tracklistViews[id];
+		}
+	});
+	Object.keys(tracklistScroll).forEach(function(id) {
+		const card = document.getElementById(id);
+		const el = card && card.querySelector('.tracklist');
+		if (el) {
+			el.scrollTop = tracklistScroll[id];
+		} else {
+			delete tracklistScroll[id];
 		}
 	});
 });

--- a/ui/static/odio.js
+++ b/ui/static/odio.js
@@ -89,6 +89,34 @@ document.addEventListener('keydown', e => {
 	if (e.key === 'Escape') closeArtZoom();
 });
 
+// ── Tracklist view ──────────────────────────────────────────────────────────
+
+// data-view on the player card switches the media slot between cover and
+// tracklist (group-data-[view=tracklist]: variants drive visibility). Chosen
+// views are remembered by card id and reapplied after SSE swaps, like
+// detailsState; the entry is dropped when the tracklist no longer renders
+// (shrunk below 2 tracks) so the card can't restore into an empty slot.
+var tracklistViews = {};
+
+function toggleTracklistView(btn) {
+	const card = btn.closest('.player-card');
+	const next = card.dataset.view === 'tracklist' ? 'cover' : 'tracklist';
+	card.dataset.view = next;
+	tracklistViews[card.id] = next;
+}
+
+document.addEventListener('htmx:afterSwap', function() {
+	Object.keys(tracklistViews).forEach(function(id) {
+		const card = document.getElementById(id);
+		if (!card) return;
+		if (card.querySelector('.tracklist')) {
+			card.dataset.view = tracklistViews[id];
+		} else {
+			delete tracklistViews[id];
+		}
+	});
+});
+
 // ── Transport buttons ───────────────────────────────────────────────────────
 
 // Both icons live in the button as <span>; group-data-[playing=true]: variants

--- a/ui/styles/input.css
+++ b/ui/styles/input.css
@@ -217,6 +217,35 @@ button.htmx-request {
 		max-height: 75cqw;
 	}
 
+	/* Tracklist view — capped to the cover's footprint, scrolls inside */
+	.tracklist {
+		@apply mb-3 overflow-y-auto rounded-md px-2;
+		max-height: 75cqw;
+	}
+
+	.tracklist-row {
+		@apply flex items-center gap-1;
+	}
+
+	.tracklist-goto {
+		@apply min-w-0 flex-1 truncate rounded px-2 py-1.5 text-left text-sm text-zinc-300 transition-colors hover:bg-zinc-700/50;
+	}
+
+	.tracklist-current .tracklist-goto {
+		@apply text-lime;
+	}
+
+	.tracklist-remove {
+		@apply shrink-0 rounded p-1 text-zinc-500 transition-colors hover:bg-zinc-700/50 hover:text-red-400;
+	}
+	.tracklist-remove svg {
+		@apply h-3.5 w-3.5;
+	}
+
+	.player-view-toggle {
+		@apply mr-2 rounded text-zinc-500 transition-colors hover:text-zinc-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-lime/50;
+	}
+
 	.art-overlay {
 		@apply fixed inset-0 z-50 flex items-center justify-center bg-zinc-950/80 p-4 backdrop-blur-sm cursor-zoom-out;
 	}

--- a/ui/styles/input.css
+++ b/ui/styles/input.css
@@ -213,8 +213,16 @@ button.htmx-request {
 	}
 
 	.player-art {
-		@apply mx-auto w-full max-w-[75%] rounded-md mb-2;
+		@apply mx-auto w-full max-w-[75%] rounded-md mb-2 cursor-zoom-in;
 		max-height: 75cqw;
+	}
+
+	.art-overlay {
+		@apply fixed inset-0 z-50 flex items-center justify-center bg-zinc-950/80 p-4 backdrop-blur-sm cursor-zoom-out;
+	}
+
+	.art-overlay img {
+		@apply max-h-full max-w-full rounded-lg shadow-2xl;
 	}
 
 	.btn {

--- a/ui/templates/base.gohtml
+++ b/ui/templates/base.gohtml
@@ -123,6 +123,11 @@
 	</footer>
 	{{ end }}
 
+	<!-- Fullscreen cover zoom; click or Escape closes -->
+	<div id="art-overlay" class="art-overlay hidden" onclick="closeArtZoom()">
+		<img alt="cover">
+	</div>
+
 	<script src="/ui/static/odio.js"></script>
 </body>
 </html>

--- a/ui/templates/components/icons.gohtml
+++ b/ui/templates/components/icons.gohtml
@@ -43,3 +43,7 @@
 {{ define "icon-arrow-up" }}<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m5 12 7-7 7 7"/><path d="M12 19V5"/></svg>{{ end }}
 
 {{ define "icon-triangle-alert" }}<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z"/><path d="M12 9v4"/><path d="M12 17h.01"/></svg>{{ end }}
+
+{{ define "icon-list-music" }}<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15V6"/><path d="M18.5 18a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5Z"/><path d="M12 12H3"/><path d="M16 6H3"/><path d="M12 18H3"/></svg>{{ end }}
+
+{{ define "icon-x" }}<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>{{ end }}

--- a/ui/templates/components/mpris_player.gohtml
+++ b/ui/templates/components/mpris_player.gohtml
@@ -1,11 +1,16 @@
 {{ define "mpris-player" }}
-<details id="player-{{ .Name }}" class="player-card" open>
+<details id="player-{{ .Name }}" class="player-card group" data-view="cover" open>
 	<summary class="player-summary">
 		<span class="player-name flex-1 text-center">{{ .DisplayName }}</span>
+		{{ if .ShowTracklist }}
+		<button class="player-view-toggle group-data-[view=tracklist]:text-lime" title="Tracklist"
+				onclick="event.preventDefault(); toggleTracklistView(this)">{{ template "icon-list-music" }}</button>
+		{{ end }}
 		<span class="player-toggle">▾</span>
 	</summary>
 
 	{{ template "mpris-track-info" . }}
+	{{ template "mpris-tracklist" . }}
 	{{ template "mpris-seeker" . }}
 
 	{{ if ne .Volume nil }}

--- a/ui/templates/components/mpris_player_parts.gohtml
+++ b/ui/templates/components/mpris_player_parts.gohtml
@@ -1,6 +1,6 @@
 {{ define "mpris-track-info" }}
-<!-- Cover + track info (centered) -->
-<div class="text-center mb-3">
+<!-- Cover + track info (centered); hidden while the card shows the tracklist -->
+<div class="text-center mb-3 group-data-[view=tracklist]:hidden">
 	{{ if .ArtUrl }}
 	<img src="{{ .ArtUrl }}" alt="cover" class="player-art" onclick="openArtZoom(this)">
 	{{ end }}
@@ -17,6 +17,27 @@
 	<div class="player-meta-small" title="{{ .Album }}">{{ .Album }}</div>
 	{{ end }}
 </div>
+{{ end }}
+
+{{ define "mpris-tracklist" }}
+{{ if .ShowTracklist }}
+<!-- Takes the cover's slot when the card's data-view is "tracklist" -->
+<div class="tracklist hidden group-data-[view=tracklist]:block">
+	{{ range .Tracks }}
+	<div class="tracklist-row{{ if .Current }} tracklist-current{{ end }}">
+		<button class="tracklist-goto"
+				title="{{ if .Artist }}{{ .Artist }} – {{ end }}{{ .Label }}"
+				hx-post="/players/{{ $.Name }}/tracklist/goto/{{ .Ref }}"
+				hx-swap="none">{{ .Label }}</button>
+		{{ if $.CanEditTracks }}
+		<button class="tracklist-remove" title="Remove track"
+				hx-post="/players/{{ $.Name }}/tracklist/remove/{{ .Ref }}"
+				hx-swap="none">{{ template "icon-x" }}</button>
+		{{ end }}
+	</div>
+	{{ end }}
+</div>
+{{ end }}
 {{ end }}
 
 {{ define "mpris-seeker" }}

--- a/ui/templates/components/mpris_player_parts.gohtml
+++ b/ui/templates/components/mpris_player_parts.gohtml
@@ -2,7 +2,7 @@
 <!-- Cover + track info (centered) -->
 <div class="text-center mb-3">
 	{{ if .ArtUrl }}
-	<img src="{{ .ArtUrl }}" alt="cover" class="player-art">
+	<img src="{{ .ArtUrl }}" alt="cover" class="player-art" onclick="openArtZoom(this)">
 	{{ end }}
 	{{ if or .Artist .Title }}
 	<div class="player-meta" title="{{ if .Artist }}{{ .Artist }}{{ end }}{{ if and .Artist .Title }} – {{ end }}{{ if .Title }}{{ .Title }}{{ end }}">

--- a/ui/types.go
+++ b/ui/types.go
@@ -111,17 +111,30 @@ type PlayerCapabilities struct {
 
 // Player represents an MPRIS player from /players
 type Player struct {
-	Name              string             `json:"bus_name"` // API returns "bus_name", not "name"
-	Identity          string             `json:"identity"` // human-readable name from MPRIS (e.g. "Chrome", "Spotify")
-	Metadata          map[string]string  `json:"metadata"`
-	Status            string             `json:"playback_status"` // API returns "playback_status", not "status"
-	Position          int64              `json:"position"`
-	PositionUpdatedAt time.Time          `json:"position_updated_at"`
-	Rate              float64            `json:"rate"`
-	Volume            *float64           `json:"volume"`
-	Shuffle           bool               `json:"shuffle"`     // omitted by backend when false (omitempty)
-	LoopStatus        *string            `json:"loop_status"` // pointer: nil ⇒ player doesn't expose LoopStatus
-	Capabilities      PlayerCapabilities `json:"capabilities"`
+	Name               string             `json:"bus_name"` // API returns "bus_name", not "name"
+	Identity           string             `json:"identity"` // human-readable name from MPRIS (e.g. "Chrome", "Spotify")
+	Metadata           map[string]string  `json:"metadata"`
+	Status             string             `json:"playback_status"` // API returns "playback_status", not "status"
+	Position           int64              `json:"position"`
+	PositionUpdatedAt  time.Time          `json:"position_updated_at"`
+	Rate               float64            `json:"rate"`
+	Volume             *float64           `json:"volume"`
+	Shuffle            bool               `json:"shuffle"`     // omitted by backend when false (omitempty)
+	LoopStatus         *string            `json:"loop_status"` // pointer: nil ⇒ player doesn't expose LoopStatus
+	Capabilities       PlayerCapabilities `json:"capabilities"`
+	TracklistSupported bool               `json:"tracklist_supported"`
+}
+
+// Track represents an entry from /players/{name}/tracklist
+type Track struct {
+	TrackID  string            `json:"track_id"`
+	Metadata map[string]string `json:"metadata"`
+}
+
+// TracklistResponse is the GET /players/{name}/tracklist payload
+type TracklistResponse struct {
+	CanEditTracks bool    `json:"can_edit_tracks"`
+	Tracks        []Track `json:"tracks"`
 }
 
 // AudioOutput represents a PulseAudio/PipeWire sink from /audio
@@ -241,6 +254,21 @@ type PlayerView struct {
 	Rate              float64 // Playback rate (1.0 = normal speed)
 	CanSeek           bool
 	PositionUpdatedAt string // RFC3339 timestamp of the last per-player position write
+	// Tracklist — empty when the player doesn't expose one
+	Tracks        []TrackView
+	CanEditTracks bool
+}
+
+// ShowTracklist reports whether the tracklist view is worth a toggle:
+// a list of 0 or 1 track offers nothing over the cover.
+func (v PlayerView) ShowTracklist() bool { return len(v.Tracks) >= 2 }
+
+// TrackView is a view-optimized tracklist entry for templates
+type TrackView struct {
+	Ref     string // %2F-encoded full track ID, used as the API path reference
+	Label   string // track title, falling back to the ID's last segment
+	Artist  string
+	Current bool // matches the player's mpris:trackid
 }
 
 // ServiceView is a view-optimized version of Service for templates


### PR DESCRIPTION
Clicking the cover opens a translucent lightbox overlay; click or Escape closes it. The overlay lives in base.gohtml, outside the SSE-swapped sections, so it survives section re-renders.


Claude-Session: https://claude.ai/code/session_01AKi5652rX9cdUDycdU1btS