### PR TITLE
fix(mpris): ignore duplicate TrackAdded signals

### DIFF
--- a/backend/mpris/tracklist.go
+++ b/backend/mpris/tracklist.go
@@ -95,11 +95,19 @@ func (m *MPRISBackend) ReplaceTracklist(busName string, tracks []Track) error {
 }
 
 // AddTrackToCache inserts a track after afterTrack (TrackAdded signal).
+// Track IDs are unique within a tracklist per spec, so a TrackAdded for an
+// already-cached ID is a duplicate signal and is ignored.
 func (m *MPRISBackend) AddTrackToCache(busName string, track Track, afterTrack string) error {
 	return m.mutateTracklist(busName, func(p *Player) bool {
 		// A player emitting TrackList signals supports the interface even if
 		// the initial GetAll failed (lazy init).
 		p.TracklistSupported = true
+		for i := range p.Tracklist {
+			if p.Tracklist[i].TrackID == track.TrackID {
+				logger.Debug("[mpris] ignoring duplicate TrackAdded %s for %s", track.TrackID, busName)
+				return false
+			}
+		}
 		p.Tracklist = insertTrack(p.Tracklist, track, afterTrack)
 		return true
 	})

--- a/backend/mpris/tracklist_test.go
+++ b/backend/mpris/tracklist_test.go
@@ -177,15 +177,25 @@ func TestAddTrackToCache(t *testing.T) {
 	tests := []struct {
 		name       string
 		busName    string
+		trackID    string // defaults to /track/new
 		afterTrack string
 		wantIDs    []string
 		wantErr    bool
+		noop       bool // duplicate signal: nothing stored, supported flag untouched
 	}{
 		{
 			name:       "prepend via NoTrack sentinel",
 			busName:    testBus,
 			afterTrack: MPRIS_NO_TRACK,
 			wantIDs:    []string{"/track/new", "/track/1", "/track/2"},
+		},
+		{
+			name:       "duplicate TrackAdded for a cached ID is a no-op",
+			busName:    testBus,
+			trackID:    "/track/1",
+			afterTrack: "/track/2",
+			wantIDs:    []string{"/track/1", "/track/2"},
+			noop:       true,
 		},
 		{
 			name:       "insert after existing track",
@@ -214,7 +224,11 @@ func TestAddTrackToCache(t *testing.T) {
 				Tracklist: append([]Track{}, initial...),
 			})
 
-			err := b.AddTrackToCache(tt.busName, newTrack, tt.afterTrack)
+			track := newTrack
+			if tt.trackID != "" {
+				track.TrackID = tt.trackID
+			}
+			err := b.AddTrackToCache(tt.busName, track, tt.afterTrack)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("AddTrackToCache error = %v, wantErr %v", err, tt.wantErr)
 			}
@@ -223,8 +237,8 @@ func TestAddTrackToCache(t *testing.T) {
 			}
 
 			p, _ := b.GetPlayerFromCache(testBus)
-			if !p.TracklistSupported {
-				t.Error("AddTrackToCache should mark the player as tracklist-supported")
+			if p.TracklistSupported == tt.noop {
+				t.Errorf("TracklistSupported = %v: an insert should set it, a no-op should store nothing", p.TracklistSupported)
 			}
 			assertTrackIDs(t, p.Tracklist, tt.wantIDs)
 		})


### PR DESCRIPTION
Some bridges emit TrackAdded twice for a single queue insert, which duplicated the track in the cache. Track IDs are unique within a tracklist per spec, so a TrackAdded for an already-cached ID is a duplicate and is now a no-op.


Claude-Session: https://claude.ai/code/session_01AKi5652rX9cdUDycdU1btS