### PR TITLE
fix Bluetooth client volume lookup

### DIFF
--- a/backend/pulseaudio/pulseaudio.go
+++ b/backend/pulseaudio/pulseaudio.go
@@ -393,11 +393,25 @@ func (pa *PulseAudioBackend) findSinkInput(name string) (pulseaudio.SinkInput, e
 		return pulseaudio.SinkInput{}, fmt.Errorf("failed to list sink inputs: %w", err)
 	}
 	for _, s := range inputs {
-		if strings.EqualFold(clientName(s.PropList), name) {
+		if sinkInputMatchesName(s.PropList, name) {
 			return s, nil
 		}
 	}
 	return pulseaudio.SinkInput{}, &NotFoundError{Resource: "client", Name: name}
+}
+
+// sinkInputMatchesName accepts both the raw PulseAudio stream name and the
+// Bluetooth display name exposed by parsePulseBluetoothSink. Bluetooth A2DP
+// inputs are implemented as module-loopback streams whose raw media.name is
+// "Loopback from <device>", while the API deliberately exposes just <device>.
+func sinkInputMatchesName(props map[string]string, name string) bool {
+	if strings.EqualFold(clientName(props), name) {
+		return true
+	}
+	if props["media.icon_name"] == "audio-card-bluetooth" {
+		return strings.EqualFold(strings.TrimPrefix(props["media.name"], "Loopback from "), name)
+	}
+	return false
 }
 
 func (pa *PulseAudioBackend) parseSinkInput(s pulseaudio.SinkInput) AudioClient {

--- a/backend/pulseaudio/pulseaudio_test.go
+++ b/backend/pulseaudio/pulseaudio_test.go
@@ -127,6 +127,49 @@ func TestCloneProps(t *testing.T) {
 	}
 }
 
+func TestSinkInputMatchesName(t *testing.T) {
+	tests := []struct {
+		name   string
+		props  map[string]string
+		target string
+		want   bool
+	}{
+		{
+			name: "regular stream name",
+			props: map[string]string{
+				"media.name": "Playback",
+			},
+			target: "Playback",
+			want:   true,
+		},
+		{
+			name: "bluetooth display name",
+			props: map[string]string{
+				"media.name":      "Loopback from Cloud Remaster",
+				"media.icon_name": "audio-card-bluetooth",
+			},
+			target: "Cloud Remaster",
+			want:   true,
+		},
+		{
+			name: "non-bluetooth prefix is not stripped",
+			props: map[string]string{
+				"media.name": "Loopback from Cloud Remaster",
+			},
+			target: "Cloud Remaster",
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sinkInputMatchesName(tt.props, tt.target); got != tt.want {
+				t.Fatalf("sinkInputMatchesName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestExtractModuleSource(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## What changed

Fixes #137.

- accept the Bluetooth display name when resolving a PulseAudio sink input for volume and mute operations
- retain support for the raw `media.name`
- add regression coverage for regular streams, Bluetooth loopbacks, and non-Bluetooth loopbacks

## Why

PulseAudio represents an A2DP source through a loopback sink input named `Loopback from <device>`. The API read path deliberately exposes that client as `<device>`, but the write path searched only the raw PulseAudio name. As a result, the UI displayed a Bluetooth volume slider whose request failed with `client not found: <device>`.

## User impact

Per-client volume and mute controls now work for Bluetooth A2DP sources using the same friendly name returned by `/audio/clients`.

## Validation

- `go test ./backend/pulseaudio -run '^TestSinkInputMatchesName$' -count=1`
- cross-compiled for Linux arm64 and exercised against a live PulseAudio Bluetooth loopback
- confirmed `POST /audio/clients/Cloud%20Remaster/volume` changed from `404 Not Found` to `202 Accepted`

The complete `backend/pulseaudio` test package was also attempted on macOS; its unrelated existing `TestCookie` fixture fails because `os.UserConfigDir` resolves to `~/Library/Application Support` rather than the test's `XDG_CONFIG_HOME`.
