### PR TITLE
fix(mpris): bound D-Bus calls with a real deadline and wait for gorou…

### DIFF
--- a/backend/bluetooth/dbus.go
+++ b/backend/bluetooth/dbus.go
@@ -1,6 +1,8 @@
 package bluetooth
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -14,43 +16,37 @@ import (
 
 var macRegex = regexp.MustCompile(`^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$`)
 
-// callWithTimeout executes a D-Bus call with timeout
-func callWithTimeout(call *dbus.Call, timeout time.Duration) error {
-	done := make(chan error, 1)
-
-	go func() {
-		done <- call.Err
-	}()
-
-	select {
-	case err := <-done:
-		return err
-	case <-time.After(timeout):
-		return &dbusTimeoutError{}
+// call issues a method call bounded by timeout. The deadline has to be on the
+// call itself: obj.Call blocks until a reply, so wrapping it afterwards never
+// times out.
+func call(obj dbus.BusObject, timeout time.Duration, method string, args ...interface{}) *dbus.Call {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	c := obj.CallWithContext(ctx, method, 0, args...)
+	if errors.Is(c.Err, context.DeadlineExceeded) {
+		c.Err = &dbusTimeoutError{}
 	}
+	return c
 }
 
-// callWithTimeout receiver method for BluetoothBackend
-func (b *BluetoothBackend) callWithTimeout(call *dbus.Call) error {
-	return callWithTimeout(call, b.timeout)
+func (b *BluetoothBackend) call(obj dbus.BusObject, method string, args ...interface{}) *dbus.Call {
+	return call(obj, b.timeout, method, args...)
 }
 
-// callMethod calls a method on an object with timeout
 func (b *BluetoothBackend) callMethod(obj dbus.BusObject, method string, args ...interface{}) error {
-	return b.callWithTimeout(obj.Call(method, 0, args...))
+	return b.call(obj, method, args...).Err
 }
 
 func (b *BluetoothBackend) setProperty(obj dbus.BusObject, iface, prop string, value interface{}) error {
-	call := obj.Call(DBUS_PROP_SET, 0, iface, prop, dbus.MakeVariant(value))
-	return b.callWithTimeout(call)
+	return b.call(obj, DBUS_PROP_SET, iface, prop, dbus.MakeVariant(value)).Err
 }
 
 // getProperty retrieves a property from D-Bus for a given busName
 func (b *BluetoothBackend) getProperty(obj dbus.BusObject, iface, prop string) (dbus.Variant, error) {
 	var v dbus.Variant
-	call := obj.Call(DBUS_PROP_GET, 0, iface, prop)
-	if err := b.callWithTimeout(call); err != nil {
-		return dbus.Variant{}, err
+	call := b.call(obj, DBUS_PROP_GET, iface, prop)
+	if call.Err != nil {
+		return dbus.Variant{}, call.Err
 	}
 	if err := call.Store(&v); err != nil {
 		return dbus.Variant{}, err
@@ -67,14 +63,7 @@ func (b *BluetoothBackend) adapter() dbus.BusObject {
 }
 
 func (b *BluetoothBackend) setAdapterProp(prop string, value interface{}) error {
-	call := b.adapter().Call(
-		DBUS_PROP_SET,
-		0,
-		BLUETOOTH_ADAPTER,
-		prop,
-		dbus.MakeVariant(value),
-	)
-	return b.callWithTimeout(call)
+	return b.setProperty(b.adapter(), BLUETOOTH_ADAPTER, prop, value)
 }
 
 func extractBool(v dbus.Variant) (bool, bool) {
@@ -255,8 +244,10 @@ func (b *BluetoothBackend) setDiscoveryFilter() error {
 	return nil
 }
 
+// connectDevice gets the pairing deadline: a first connect bonds the device
+// and takes several seconds, well past the generic call timeout.
 func (b *BluetoothBackend) connectDevice(path dbus.ObjectPath) error {
-	return b.callMethod(b.getObj(BLUETOOTH_PREFIX, string(path)), DEVICE_CONNECT)
+	return call(b.getObj(BLUETOOTH_PREFIX, string(path)), b.pairingTimeout, DEVICE_CONNECT).Err
 }
 
 func (b *BluetoothBackend) disconnectDevice(path dbus.ObjectPath) error {
@@ -356,7 +347,7 @@ func (b *BluetoothBackend) SetTimeOut(prop string) error {
 func (b *BluetoothBackend) getManagedObjects() (map[dbus.ObjectPath]map[string]map[string]dbus.Variant, error) {
 	objManager := b.getObj(BLUETOOTH_PREFIX, "/")
 	var managedObjects map[dbus.ObjectPath]map[string]map[string]dbus.Variant
-	if err := objManager.Call(MANAGED_OBJECTS, 0).Store(&managedObjects); err != nil {
+	if err := b.call(objManager, MANAGED_OBJECTS).Store(&managedObjects); err != nil {
 		logger.Warn("[bluetooth] failed to query BlueZ managed objects: %v", err)
 		return nil, err
 	}

--- a/backend/login1/dbus.go
+++ b/backend/login1/dbus.go
@@ -1,42 +1,34 @@
 package login1
 
 import (
-	"time"
+	"context"
+	"errors"
 
 	"github.com/godbus/dbus/v5"
 )
 
-// callWithTimeout executes a D-Bus call with timeout
-func callWithTimeout(call *dbus.Call, timeout time.Duration) error {
-	done := make(chan error, 1)
-
-	go func() {
-		done <- call.Err
-	}()
-
-	select {
-	case err := <-done:
-		return err
-	case <-time.After(timeout):
-		return &dbusTimeoutError{}
+// call issues a method call bounded by the backend timeout. The deadline has
+// to be on the call itself: obj.Call blocks until a reply, so wrapping it
+// afterwards never times out.
+func (l *Login1Backend) call(obj dbus.BusObject, method string, args ...interface{}) *dbus.Call {
+	ctx, cancel := context.WithTimeout(context.Background(), l.timeout)
+	defer cancel()
+	c := obj.CallWithContext(ctx, method, 0, args...)
+	if errors.Is(c.Err, context.DeadlineExceeded) {
+		c.Err = &dbusTimeoutError{}
 	}
+	return c
 }
 
 func (l *Login1Backend) callMethod(busName, method string, args ...interface{}) error {
-	obj := l.conn.Object(busName, LOGIN1_PATH)
-	return l.callWithTimeout(obj.Call(method, 0, args...))
-}
-
-func (l *Login1Backend) callWithTimeout(call *dbus.Call) error {
-	return callWithTimeout(call, l.timeout)
+	return l.call(l.conn.Object(busName, LOGIN1_PATH), method, args...).Err
 }
 
 // callDBusMethod calls a D-Bus method and returns the call for further processing
 func (l *Login1Backend) callDBusMethod(method string, args ...interface{}) (*dbus.Call, error) {
-	obj := l.conn.Object(LOGIN1_PREFIX, LOGIN1_PATH)
-	call := obj.Call(method, 0, args...)
-	if err := l.callWithTimeout(call); err != nil {
-		return nil, err
+	call := l.call(l.conn.Object(LOGIN1_PREFIX, LOGIN1_PATH), method, args...)
+	if call.Err != nil {
+		return nil, call.Err
 	}
 	return call, nil
 }

--- a/backend/mpris/dbus.go
+++ b/backend/mpris/dbus.go
@@ -1,6 +1,8 @@
 package mpris
 
 import (
+	"context"
+	"errors"
 	"strings"
 	"time"
 
@@ -22,46 +24,40 @@ func validateBusName(busName string) error {
 	return nil
 }
 
-// callWithTimeout executes a D-Bus call with timeout
-func callWithTimeout(call *dbus.Call, timeout time.Duration) error {
-	done := make(chan error, 1)
-
-	go func() {
-		done <- call.Err
-	}()
-
-	select {
-	case err := <-done:
-		return err
-	case <-time.After(timeout):
-		return &dbusTimeoutError{}
+// call issues a method call bounded by timeout. The deadline must be on the
+// call itself: obj.Call blocks until a reply, and some players (Kodi) never
+// reply to interfaces they don't implement, which used to freeze the caller
+// until the player left the bus.
+func call(obj dbus.BusObject, timeout time.Duration, method string, args ...interface{}) *dbus.Call {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	c := obj.CallWithContext(ctx, method, 0, args...)
+	if errors.Is(c.Err, context.DeadlineExceeded) {
+		c.Err = &dbusTimeoutError{}
 	}
+	return c
 }
 
-// callWithTimeout receiver method for MPRISBackend
-func (m *MPRISBackend) callWithTimeout(call *dbus.Call) error {
-	return callWithTimeout(call, m.timeout)
+func (m *MPRISBackend) call(obj dbus.BusObject, method string, args ...interface{}) *dbus.Call {
+	return call(obj, m.timeout, method, args...)
 }
 
-// callMethod calls an MPRIS method on a player with timeout
 func (m *MPRISBackend) callMethod(busName, method string, args ...interface{}) error {
 	obj := m.conn.Object(busName, MPRIS_PATH)
-	return m.callWithTimeout(obj.Call(method, 0, args...))
+	return m.call(obj, method, args...).Err
 }
 
-// setProperty sets a property on a player
 func (m *MPRISBackend) setProperty(busName, property string, value interface{}) error {
 	obj := m.conn.Object(busName, MPRIS_PATH)
-	return m.callWithTimeout(obj.Call(DBUS_PROP_SET, 0, MPRIS_PLAYER_IFACE, property, dbus.MakeVariant(value)))
+	return m.call(obj, DBUS_PROP_SET, MPRIS_PLAYER_IFACE, property, dbus.MakeVariant(value)).Err
 }
 
-// getProperty retrieves a property from D-Bus for a given busName
 func (m *MPRISBackend) getProperty(busName, iface, prop string) (dbus.Variant, error) {
 	obj := m.conn.Object(busName, MPRIS_PATH)
 	var v dbus.Variant
-	call := obj.Call(DBUS_PROP_GET, 0, iface, prop)
-	if err := m.callWithTimeout(call); err != nil {
-		return dbus.Variant{}, err
+	call := m.call(obj, DBUS_PROP_GET, iface, prop)
+	if call.Err != nil {
+		return dbus.Variant{}, call.Err
 	}
 	if err := call.Store(&v); err != nil {
 		return dbus.Variant{}, err
@@ -72,9 +68,9 @@ func (m *MPRISBackend) getProperty(busName, iface, prop string) (dbus.Variant, e
 // listDBusNames retrieves the list of all bus names on D-Bus
 func (m *MPRISBackend) listDBusNames() ([]string, error) {
 	var names []string
-	call := m.conn.BusObject().Call(DBUS_LIST_NAMES_METHOD, 0)
-	if err := m.callWithTimeout(call); err != nil {
-		return nil, err
+	call := m.call(m.conn.BusObject(), DBUS_LIST_NAMES_METHOD)
+	if call.Err != nil {
+		return nil, call.Err
 	}
 	if err := call.Store(&names); err != nil {
 		return nil, err
@@ -84,8 +80,7 @@ func (m *MPRISBackend) listDBusNames() ([]string, error) {
 
 // addMatchRule subscribes to a D-Bus signal via a match rule
 func (m *MPRISBackend) addMatchRule(rule string) error {
-	call := m.conn.BusObject().Call(DBUS_ADD_MATCH_METHOD, 0, rule)
-	return m.callWithTimeout(call)
+	return m.call(m.conn.BusObject(), DBUS_ADD_MATCH_METHOD, rule).Err
 }
 
 // addListenMatchRules subscribes to the necessary D-Bus signals for the listener.
@@ -114,9 +109,9 @@ func (m *MPRISBackend) addListenMatchRules() error {
 
 func (m *MPRISBackend) getNameOwner(busName string) (string, error) {
 	var owner string
-	call := m.conn.BusObject().Call(DBUS_GET_NAME_OWNER, 0, busName)
-	if err := m.callWithTimeout(call); err != nil {
-		return "", err
+	call := m.call(m.conn.BusObject(), DBUS_GET_NAME_OWNER, busName)
+	if call.Err != nil {
+		return "", call.Err
 	}
 	if err := call.Store(&owner); err != nil {
 		return "", err
@@ -141,19 +136,17 @@ func extract[T any](v dbus.Variant) (T, bool) {
 	return val, ok
 }
 
-// callWithTimeout receiver method for Player
-func (p *Player) callWithTimeout(call *dbus.Call) error {
-	return callWithTimeout(call, p.timeout)
+func (p *Player) call(method string, args ...interface{}) *dbus.Call {
+	return call(p.conn.Object(p.BusName, MPRIS_PATH), p.timeout, method, args...)
 }
 
 // getAllProperties retrieves all properties of a D-Bus interface in a single call
 func (p *Player) getAllProperties(iface string) (map[string]dbus.Variant, error) {
-	obj := p.conn.Object(p.BusName, MPRIS_PATH)
 	var props map[string]dbus.Variant
 
-	call := obj.Call(DBUS_PROP_GET_ALL, 0, iface)
-	if err := p.callWithTimeout(call); err != nil {
-		return nil, err
+	call := p.call(DBUS_PROP_GET_ALL, iface)
+	if call.Err != nil {
+		return nil, call.Err
 	}
 
 	err := call.Store(&props)
@@ -163,12 +156,11 @@ func (p *Player) getAllProperties(iface string) (map[string]dbus.Variant, error)
 // getTracksMetadata retrieves metadata for the given track IDs in a single call.
 // The spec guarantees results in the same order as the requested IDs.
 func (p *Player) getTracksMetadata(ids []dbus.ObjectPath) ([]map[string]dbus.Variant, error) {
-	obj := p.conn.Object(p.BusName, MPRIS_PATH)
 	var metas []map[string]dbus.Variant
 
-	call := obj.Call(MPRIS_METHOD_GET_TRACKS_METADATA, 0, ids)
-	if err := p.callWithTimeout(call); err != nil {
-		return nil, err
+	call := p.call(MPRIS_METHOD_GET_TRACKS_METADATA, ids)
+	if call.Err != nil {
+		return nil, call.Err
 	}
 
 	err := call.Store(&metas)

--- a/backend/mpris/dbus_test.go
+++ b/backend/mpris/dbus_test.go
@@ -1,0 +1,164 @@
+package mpris
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/godbus/dbus/v5"
+
+	"github.com/b0bbywan/go-odio-api/config"
+)
+
+// silentTracklistPlayer mimics Kodi: it answers the two mandatory interfaces
+// but never replies to a GetAll on TrackList.
+type silentTracklistPlayer struct {
+	hang chan struct{}
+}
+
+func (p *silentTracklistPlayer) GetAll(iface string) (map[string]dbus.Variant, *dbus.Error) {
+	switch iface {
+	case MPRIS_INTERFACE:
+		return map[string]dbus.Variant{"Identity": dbus.MakeVariant("Silent")}, nil
+	case MPRIS_PLAYER_IFACE:
+		return map[string]dbus.Variant{
+			"PlaybackStatus": dbus.MakeVariant("Playing"),
+			"CanPlay":        dbus.MakeVariant(true),
+		}, nil
+	}
+	<-p.hang
+	return nil, dbus.MakeFailedError(errors.New("unknown interface"))
+}
+
+func (p *silentTracklistPlayer) Get(iface, prop string) (dbus.Variant, *dbus.Error) {
+	<-p.hang
+	return dbus.Variant{}, dbus.MakeFailedError(errors.New("unknown interface"))
+}
+
+// exportSilentPlayer registers the fake player on the session bus under a
+// unique MPRIS name. Skips the test when no session bus is reachable.
+func exportSilentPlayer(t *testing.T) string {
+	t.Helper()
+	conn, err := dbus.ConnectSessionBus()
+	if err != nil {
+		t.Skipf("no session bus: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	hang := make(chan struct{})
+	t.Cleanup(func() { close(hang) })
+	if err := conn.Export(&silentTracklistPlayer{hang: hang}, MPRIS_PATH, DBUS_PROP_IFACE); err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+
+	name := fmt.Sprintf("%s.odio_test_%d_%d", MPRIS_PREFIX, os.Getpid(), time.Now().UnixNano())
+	reply, err := conn.RequestName(name, dbus.NameFlagDoNotQueue)
+	if err != nil || reply != dbus.RequestNameReplyPrimaryOwner {
+		t.Fatalf("RequestName(%s) = %v, %v", name, reply, err)
+	}
+	return name
+}
+
+func startBackend(t *testing.T, timeout time.Duration) *MPRISBackend {
+	t.Helper()
+	b, err := New(context.Background(), &config.MPRISConfig{Enabled: true, Timeout: timeout})
+	if err != nil {
+		t.Skipf("no session bus: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- b.Start() }()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Start: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start blocked on the silent TrackList probe")
+	}
+	return b
+}
+
+func findPlayer(t *testing.T, b *MPRISBackend, name string) *Player {
+	t.Helper()
+	players, err := b.ListPlayers()
+	if err != nil {
+		t.Fatalf("ListPlayers: %v", err)
+	}
+	for i := range players {
+		if players[i].BusName == name {
+			return &players[i]
+		}
+	}
+	return nil
+}
+
+// A player that never answers the optional TrackList probe must still be
+// listed, without tracklist support, once the call deadline expires.
+func TestSilentTracklistPlayerIsListed(t *testing.T) {
+	name := exportSilentPlayer(t)
+	b := startBackend(t, 100*time.Millisecond)
+	defer b.Close()
+
+	p := findPlayer(t, b, name)
+	if p == nil {
+		t.Fatalf("player %s not listed", name)
+	}
+	if p.TracklistSupported {
+		t.Error("TracklistSupported = true, want false")
+	}
+	if p.Identity != "Silent" {
+		t.Errorf("Identity = %q, want Silent", p.Identity)
+	}
+}
+
+func TestCallTimeoutError(t *testing.T) {
+	name := exportSilentPlayer(t)
+	b := startBackend(t, 50*time.Millisecond)
+	defer b.Close()
+
+	start := time.Now()
+	_, err := b.getProperty(name, MPRIS_TRACKLIST_IFACE, "Tracks")
+	var timeoutErr *dbusTimeoutError
+	if !errors.As(err, &timeoutErr) {
+		t.Fatalf("getProperty error = %v, want dbusTimeoutError", err)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Errorf("call took %s, deadline not enforced", elapsed)
+	}
+}
+
+// Close must wait for the listener's in-flight handler: a player appearing
+// right before shutdown used to reach notify() after the events channel was
+// closed and panic the process.
+func TestCloseDuringInFlightReload(t *testing.T) {
+	b := startBackend(t, 500*time.Millisecond)
+
+	// Appears after Start so it is handled by the listener, not ListPlayers.
+	exportSilentPlayer(t)
+	time.Sleep(50 * time.Millisecond)
+
+	closed := make(chan struct{})
+	go func() {
+		b.Close()
+		close(closed)
+	}()
+	select {
+	case <-closed:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Close did not return")
+	}
+	for {
+		select {
+		case _, ok := <-b.Events():
+			if !ok {
+				return
+			}
+		case <-time.After(time.Second):
+			t.Fatal("events channel still open after Close")
+		}
+	}
+}

--- a/backend/mpris/heartbeat.go
+++ b/backend/mpris/heartbeat.go
@@ -18,6 +18,7 @@ type Heartbeat struct {
 
 	mu     sync.Mutex
 	active bool
+	wg     sync.WaitGroup
 }
 
 // NewHeartbeat creates a new heartbeat manager
@@ -42,12 +43,15 @@ func (h *Heartbeat) Start() {
 	}
 
 	h.active = true
+	h.wg.Add(1)
 	go h.run()
 }
 
-// Stop stops the heartbeat
+// Stop returns once the run goroutine has exited; the heartbeat cannot be
+// restarted afterwards.
 func (h *Heartbeat) Stop() {
 	h.cancel()
+	h.wg.Wait()
 }
 
 // IsRunning returns true if the heartbeat is active
@@ -63,6 +67,7 @@ func (h *Heartbeat) run() {
 		h.mu.Lock()
 		h.active = false
 		h.mu.Unlock()
+		h.wg.Done()
 		logger.Debug("[mpris] position heartbeat stopped")
 	}()
 

--- a/backend/mpris/listener.go
+++ b/backend/mpris/listener.go
@@ -34,7 +34,11 @@ func (l *Listener) Start() error {
 	ch := make(chan *dbus.Signal, 10)
 	conn.Signal(ch)
 
-	go l.listen(ch)
+	l.wg.Add(1)
+	go func() {
+		defer l.wg.Done()
+		l.listen(ch)
+	}()
 
 	logger.Info("[mpris] listener started (D-Bus signal-based)")
 	return nil
@@ -322,9 +326,11 @@ func (l *Listener) handleTrackMetadataChanged(busName string, sig *dbus.Signal) 
 	}
 }
 
-// Stop stops the listener
+// Stop returns once the listen goroutine has exited, so callers know no
+// handler can still touch the backend afterwards.
 func (l *Listener) Stop() {
 	logger.Info("[mpris] stopping listener")
 	l.cancel()
+	l.wg.Wait()
 	logger.Debug("[mpris] listener stopped")
 }

--- a/backend/mpris/mpris.go
+++ b/backend/mpris/mpris.go
@@ -549,22 +549,24 @@ func (m *MPRISBackend) InvalidateCache() {
 	m.players.Reset()
 }
 
-// Close cleanly closes connections and stops the listener
+// Close fails in-flight D-Bus calls first so the listener and heartbeat can be
+// waited for promptly. The listener goes before the heartbeat because a
+// handler may restart it, and events is closed only once neither can notify().
 func (m *MPRISBackend) Close() {
-	if m.heartbeat != nil {
-		m.heartbeat.Stop()
-		m.heartbeat = nil
+	if m.conn != nil {
+		if err := m.conn.Close(); err != nil {
+			logger.Info("Failed to close D-Bus connection: %v", err)
+		}
 	}
 	if m.listener != nil {
 		m.listener.Stop()
 		m.listener = nil
 	}
-	if m.conn != nil {
-		if err := m.conn.Close(); err != nil {
-			logger.Info("Failed to close D-Bus connection: %v", err)
-		}
-		m.conn = nil
+	if m.heartbeat != nil {
+		m.heartbeat.Stop()
+		m.heartbeat = nil
 	}
+	m.conn = nil
 	close(m.events)
 }
 

--- a/backend/mpris/types.go
+++ b/backend/mpris/types.go
@@ -42,6 +42,7 @@ type Listener struct {
 	backend *MPRISBackend
 	ctx     context.Context
 	cancel  context.CancelFunc
+	wg      sync.WaitGroup
 
 	// Deduplication: last known state per player
 	lastState   map[string]PlaybackStatus


### PR DESCRIPTION
…tines on Close

callWithTimeout read call.Err after obj.Call had already returned, so the configured timeout never applied. Kodi never replies to the optional TrackList probe, which froze the listener (and Start) until the player left the bus; the player never reached the cache. Every call now goes through CallWithContext with mpris.timeout.

Close used to close the events channel while the listener could still be inside a handler, panicking on notify ("send on closed channel"). Listener and heartbeat Stop now wait for their goroutine; Close closes the D-Bus connection first so in-flight calls fail fast, then closes events last.


Claude-Session: https://claude.ai/code/session_01F9qZzw2ePsBw6ZeUPnzTDz