### PR TITLE
fix(ui): restate preflight resets that chromium 87 discards

### DIFF
--- a/ui/styles/input.css
+++ b/ui/styles/input.css
@@ -230,14 +230,21 @@ button.htmx-request {
 		@apply rotate-180;
 	}
 
+	/* Container queries land in chromium 105 and the framebuffer browser runs
+	   87, where the cqw declaration is dropped and the cap with it: the art
+	   stretches and the tracklist grows instead of scrolling, which swamps a
+	   480px tall pi screen. The vh fallback has to stay the same on both so
+	   the card keeps its height when toggling between the two views. */
 	.player-art {
 		@apply mx-auto w-full max-w-[75%] rounded-md mb-2 cursor-zoom-in;
+		max-height: 50vh;
 		max-height: 75cqw;
 	}
 
 	/* Tracklist view — capped to the cover's footprint, scrolls inside */
 	.tracklist {
 		@apply mb-3 overflow-y-auto rounded-md px-2;
+		max-height: 50vh;
 		max-height: 75cqw;
 	}
 

--- a/ui/styles/input.css
+++ b/ui/styles/input.css
@@ -2,6 +2,24 @@
 @tailwind components;
 @tailwind utilities;
 
+/*
+ * Preflight resets buttons through a selector list that contains :where(),
+ * understood by chromium 88 and up. Older engines drop the whole rule, the
+ * leading bare `button` selector included, and fall back to native button
+ * chrome: a white box that swallows the icon drawn inside it in currentColor.
+ * QtWebEngine 5.15 ships chromium 87, so restate the reset without :where().
+ */
+@layer base {
+	button,
+	[type='button'],
+	[type='reset'],
+	[type='submit'] {
+		-webkit-appearance: button;
+		background-color: transparent;
+		background-image: none;
+	}
+}
+
 /* Remove native <details> disclosure marker */
 details > summary {
 	list-style: none;


### PR DESCRIPTION
QtWebEngine 5.15, which the framebuffer browser on the pi runs on, ships chromium 87. Two preflight assumptions break there and both were silent:

Preflight resets buttons through a selector list containing :where(), supported from chromium 88 on. An unknown pseudo-class invalidates the whole rule, the leading bare `button` selector included, so every button without an explicit background class fell back to native chrome: a white box swallowing the icon drawn inside it in currentColor.
